### PR TITLE
docs: add link to package rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, and prevent issues with misspelling of file paths and import names. All the goodness that the ES2015+ static module syntax intends to provide, marked up in your editor.
 
+[`eslint-plugin-i` is now `eslint-plugin-import-x`](https://github.com/un-ts/eslint-plugin-import-x/issues/24#issuecomment-1991605123)
+
 **IF YOU ARE USING THIS WITH SUBLIME**: see the [bottom section](#sublimelinter-eslint) for important info.
 
 ## Rules


### PR DESCRIPTION
The repo link got redirected, and it took me a while to understand what was happening. I think it would be better to link to the context for existing `eslint-plugin-i` so that it can be understood easily and migrate.

I don't know what's the best place to put that link - feel free to move it to wherever makes more sense.