### PR TITLE
fix: support ESLint v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "watch": "yarn test --watch"
   },
   "peerDependencies": {
-    "eslint": "^7.2.0 || ^8"
+    "eslint": "^7.2.0 || ^8 || ^9.0.0-0"
   },
   "dependencies": {
     "@typescript-eslint/utils": "^5.62.0",
@@ -92,7 +92,7 @@
     "cross-env": "^7.0.3",
     "enhanced-resolve": "^5.16.0",
     "escope": "^4.0.0",
-    "eslint": "^7.2.0 || ^8",
+    "eslint": "^8",
     "eslint-config-prettier": "^9.1.0",
     "eslint-doc-generator": "^1.7.0",
     "eslint-import-resolver-typescript": "^3.6.1",

--- a/src/rules/namespace.ts
+++ b/src/rules/namespace.ts
@@ -186,7 +186,10 @@ export = createRule<[Options], MessageId>({
           return
         }
 
-        if (declaredScope(context, dereference.object.name) !== 'module') {
+        if (
+          declaredScope(context, dereference.object.name, dereference) !==
+          'module'
+        ) {
           return
         }
 
@@ -249,7 +252,8 @@ export = createRule<[Options], MessageId>({
         }
       },
 
-      VariableDeclarator({ id, init }) {
+      VariableDeclarator(node) {
+        const { id, init } = node
         if (init == null) {
           return
         }
@@ -261,7 +265,7 @@ export = createRule<[Options], MessageId>({
         }
 
         // check for redefinition in intermediate scopes
-        if (declaredScope(context, init.name) !== 'module') {
+        if (declaredScope(context, init.name, node) !== 'module') {
           return
         }
 

--- a/src/rules/newline-after-import.ts
+++ b/src/rules/newline-after-import.ts
@@ -267,14 +267,20 @@ export = createRule<[Options?], MessageId>({
           requireCalls.push(node)
         }
       },
-      'Program:exit'() {
+      'Program:exit'(node) {
         log(
           'exit processing for',
           context.getPhysicalFilename
             ? context.getPhysicalFilename()
             : context.getFilename(),
         )
-        const scopeBody = getScopeBody(context.getScope())
+
+        // For ESLint v9
+        const scope = (context as any)?.sourceCode?.getScope
+          ? (context as any).sourceCode.getScope(node)
+          : context.getScope()
+
+        const scopeBody = getScopeBody(scope)
 
         log('got scope:', scopeBody)
 

--- a/src/rules/no-amd.ts
+++ b/src/rules/no-amd.ts
@@ -2,6 +2,7 @@
  * Rule to prefer imports to AMD
  */
 
+import { TSESLint } from '@typescript-eslint/utils'
 import { createRule } from '../utils'
 
 type MessageId = 'amd'
@@ -23,7 +24,13 @@ export = createRule<[], MessageId>({
   create(context) {
     return {
       CallExpression(node) {
-        if (context.getScope().type !== 'module') {
+        // For ESLint v9
+        const scope: TSESLint.Scope.Scope = (context as any)?.sourceCode
+          ?.getScope
+          ? (context as any).sourceCode.getScope(node)
+          : context.getScope()
+
+        if (scope.type !== 'module') {
           return
         }
 

--- a/src/rules/no-commonjs.ts
+++ b/src/rules/no-commonjs.ts
@@ -122,9 +122,15 @@ export = createRule<[Options?], MessageId>({
 
         // exports.
         if ('name' in node.object && node.object.name === 'exports') {
-          const isInScope = context
-            .getScope()
-            .variables.some(variable => variable.name === 'exports')
+          // For ESLint v9
+          const scope: TSESLint.Scope.Scope = (context as any)?.sourceCode
+            ?.getScope
+            ? (context as any).sourceCode.getScope(node)
+            : context.getScope()
+
+          const isInScope = scope.variables.some(
+            variable => variable.name === 'exports',
+          )
           if (!isInScope) {
             context.report({ node, messageId: 'export' })
           }

--- a/src/rules/no-deprecated.ts
+++ b/src/rules/no-deprecated.ts
@@ -148,7 +148,7 @@ export = createRule({
           return
         }
 
-        if (declaredScope(context, node.name) !== 'module') {
+        if (declaredScope(context, node.name, node) !== 'module') {
           return
         }
         context.report({
@@ -165,7 +165,10 @@ export = createRule({
           return
         }
 
-        if (declaredScope(context, dereference.object.name) !== 'module') {
+        if (
+          declaredScope(context, dereference.object.name, dereference) !==
+          'module'
+        ) {
           return
         }
 

--- a/src/rules/no-mutable-exports.ts
+++ b/src/rules/no-mutable-exports.ts
@@ -48,14 +48,22 @@ export = createRule<[], MessageId>({
 
     return {
       ExportDefaultDeclaration(node) {
-        const scope = context.getScope()
+        // For ESLint v9
+        const scope: TSESLint.Scope.Scope = (context as any)?.sourceCode
+          ?.getScope
+          ? (context as any).sourceCode.getScope(node)
+          : context.getScope()
 
         if ('name' in node.declaration) {
           checkDeclarationsInScope(scope, node.declaration.name)
         }
       },
       ExportNamedDeclaration(node) {
-        const scope = context.getScope()
+        // For ESLint v9
+        const scope: TSESLint.Scope.Scope = (context as any)?.sourceCode
+          ?.getScope
+          ? (context as any).sourceCode.getScope(node)
+          : context.getScope()
 
         if (node.declaration) {
           checkDeclaration(node.declaration)

--- a/src/rules/no-namespace.ts
+++ b/src/rules/no-namespace.ts
@@ -59,7 +59,13 @@ export = createRule<[Options?], MessageId>({
           return
         }
 
-        const scopeVariables = context.getScope().variables
+        // For ESLint v9
+        const scope: TSESLint.Scope.Scope = (context as any)?.sourceCode
+          ?.getScope
+          ? (context as any).sourceCode.getScope(node)
+          : context.getScope()
+
+        const scopeVariables = scope.variables
         const namespaceVariable = scopeVariables.find(
           variable => variable.defs[0].node === node,
         )!

--- a/src/utils/declared-scope.ts
+++ b/src/utils/declared-scope.ts
@@ -1,7 +1,17 @@
+import { TSESTree, TSESLint } from '@typescript-eslint/utils'
 import type { RuleContext } from '../types'
 
-export function declaredScope(context: RuleContext, name: string) {
-  const references = context.getScope().references
+export function declaredScope(
+  context: RuleContext,
+  name: string,
+  node: TSESTree.Node,
+) {
+  // For ESLint v9
+  const scope: TSESLint.Scope.Scope = (context as any)?.sourceCode?.getScope
+    ? (context as any).sourceCode.getScope(node)
+    : context.getScope()
+
+  const references = scope.references
   const reference = references.find(x => x.identifier.name === name)
   if (!reference || !reference.resolved) {
     return

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,7 +3535,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-"eslint@^7.2.0 || ^8":
+eslint@^8:
   version "8.57.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.0.tgz#c786a6fd0e0b68941aaf624596fb987089195668"
   integrity sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==


### PR DESCRIPTION
fix #60 

As mentioned in #60, if we are able to upgrade `@typescript-eslint/utils` the types will be better and we won't need `as any`