### PR TITLE
fix: add `importHelpers: false` to tsconfig.json

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.base",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "../lib"
+    "outDir": "../lib",
+    "importHelpers": false
   }
 }


### PR DESCRIPTION
Close https://github.com/un-ts/eslint-plugin-import-x/issues/73

By the way, since some refactoring is going on, I suggest refactoring `export = xxx` to standard ESM syntax. I also suggest using other tools for packaging, such as tsup or unbuild.

If you agree with my suggestion, I will create another PR for this.