### PR TITLE
fix: cannot find module 'tslib'

### DIFF
--- a/.changeset/hot-sheep-visit.md
+++ b/.changeset/hot-sheep-visit.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: cannot find module 'tslib'

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "get-tsconfig": "^4.7.3",
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.3",
-    "semver": "^7.6.0"
+    "semver": "^7.6.0",
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@1stg/prettier-config": "^4.0.1",


### PR DESCRIPTION
tslib is required as a runtime dependency but not installed in this project.

Fixes #73.