### PR TITLE
fix: add languageOptions to ChildContext

### DIFF
--- a/.changeset/short-bees-sell.md
+++ b/.changeset/short-bees-sell.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+add languageOptions to ChildContext

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@typescript-eslint/utils": "^7.4.0",
     "debug": "^4.3.4",
+    "dequal": "^2.0.3",
     "doctrine": "^3.0.0",
     "eslint-import-resolver-node": "^0.3.9",
     "get-tsconfig": "^4.7.3",

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export type ChildContext = {
   settings: PluginSettings
   parserPath?: string | null
   parserOptions?: TSESLint.ParserOptions
+  languageOptions?: TSESLint.FlatConfig.LanguageOptions
   path: string
   filename?: string
 }

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -1104,7 +1104,7 @@ function childContext(
 }
 
 type OptionsHashesCache = Record<
-  'settings' | 'parserOptions' | 'parserMeta' | 'languageOptions',
+  'settings' | 'parserOptions' | 'parserMeta',
   { value: unknown; hash: string }
 >
 
@@ -1112,7 +1112,6 @@ const optionsHashesCache: OptionsHashesCache = {
   settings: { value: null, hash: '' },
   parserOptions: { value: null, hash: '' },
   parserMeta: { value: null, hash: '' },
-  languageOptions: { value: null, hash: '' },
 }
 
 function getOptionsHash(key: keyof OptionsHashesCache, value: unknown) {

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import debug from 'debug'
+import { dequal } from 'dequal'
 import type { Annotation } from 'doctrine'
 import doctrine from 'doctrine'
 import type { AST } from 'eslint'
@@ -1102,21 +1103,29 @@ function childContext(
   }
 }
 
-const optionsHashesCache: Record<
-  string,
-  { value: string; hash: string } | undefined
-> = {}
+type OptionsHashesCache = Record<
+  'settings' | 'parserOptions' | 'parserMeta' | 'languageOptions',
+  { value: unknown; hash: string }
+>
 
-function getOptionsHash(key: string, value: unknown) {
+const optionsHashesCache: OptionsHashesCache = {
+  settings: { value: null, hash: '' },
+  parserOptions: { value: null, hash: '' },
+  parserMeta: { value: null, hash: '' },
+  languageOptions: { value: null, hash: '' },
+}
+
+function getOptionsHash(key: keyof OptionsHashesCache, value: unknown) {
   const entry = optionsHashesCache[key]
-  const stringifiedValue = JSON.stringify(value)
 
-  if (stringifiedValue === entry?.value) {
+  if (dequal(value, entry.value)) {
     return entry.hash
   }
 
   const hash = hashify(value).digest('hex')
-  optionsHashesCache[key] = { value: stringifiedValue, hash }
+
+  optionsHashesCache[key].value = value
+  optionsHashesCache[key].hash = hash
 
   return hash
 }

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -1134,20 +1134,23 @@ function makeContextCacheKey(context: RuleContext | ChildContext) {
 
   let hash = getOptionsHash('settings', settings)
 
-  const usedParserOptions = languageOptions
-    ? languageOptions.parserOptions
-    : parserOptions
+  const usedParserOptions = languageOptions?.parserOptions ?? parserOptions
 
   hash += getOptionsHash('parserOptions', usedParserOptions)
 
   if (languageOptions) {
-    const { parser: { meta } = {}, ecmaVersion, sourceType } = languageOptions
-    hash +=
-      getOptionsHash('parserMeta', meta) +
-      String(ecmaVersion) +
-      String(sourceType)
+    const { ecmaVersion, sourceType } = languageOptions
+    hash += String(ecmaVersion) + String(sourceType)
+  }
+
+  if (parserPath) {
+    hash += parserPath
   } else {
-    hash += String(parserPath)
+    const { meta } = languageOptions?.parser ?? {}
+
+    if (meta) {
+      hash += getOptionsHash('parserMeta', meta)
+    }
   }
 
   return hash

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -1091,7 +1091,7 @@ function childContext(
   path: string,
   context: RuleContext | ChildContext,
 ): ChildContext {
-  const { settings, parserOptions, parserPath } = context
+  const { settings, parserOptions, parserPath, languageOptions } = context
 
   if (JSON.stringify(settings) !== prevSettings) {
     settingsHash = hashObject({ settings }).digest('hex')
@@ -1109,6 +1109,7 @@ function childContext(
     settings,
     parserOptions,
     parserPath,
+    languageOptions,
     path,
     filename:
       'physicalFilename' in context


### PR DESCRIPTION
Currently the plugin loses `languageOptions` when creating a child context (when using a flat config). This causes errors when plugin tries to use the default parser, i.e. `languageOptions.parser`

I've also created [a reproduction](https://github.com/kosmotema/epix-parser) for this bug