### PR TITLE
fix: enable isolate mode w/ typescript-eslint v8

### DIFF
--- a/.changeset/fifty-ladybugs-occur.md
+++ b/.changeset/fifty-ladybugs-occur.md
@@ -2,4 +2,4 @@
 "eslint-plugin-import-x": patch
 ---
 
-enable isolation mode w/ typescript-eslint v8
+fix: enable isolation parsing w/ typescript-eslint v8

--- a/.changeset/fifty-ladybugs-occur.md
+++ b/.changeset/fifty-ladybugs-occur.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+enable isolation mode w/ typescript-eslint v8

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -89,8 +89,11 @@ export function parse(
   // "project" or "projects" in parserOptions. Removing these options means the parser will
   // only parse one file in isolate mode, which is much, much faster.
   // https://github.com/import-js/eslint-plugin-import/issues/1408#issuecomment-509298962
+
+  // TODO: prefer https://github.com/typescript-eslint/typescript-eslint/pull/9233 when typescript-eslint v8
+  // become stable
   delete parserOptions.EXPERIMENTAL_useProjectService
-  delete parserOptions.useProjectService
+  delete parserOptions.projectService
   delete parserOptions.project
   delete parserOptions.projects
 

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -90,6 +90,7 @@ export function parse(
   // only parse one file in isolate mode, which is much, much faster.
   // https://github.com/import-js/eslint-plugin-import/issues/1408#issuecomment-509298962
   delete parserOptions.EXPERIMENTAL_useProjectService
+  delete parserOptions.useProjectService
   delete parserOptions.project
   delete parserOptions.projects
 


### PR DESCRIPTION
`typescript-eslint` v8 beta has made `projectService` stable (`EXPERIMENTAL_useProjectService` is now just `projectService`) thus previous `delete parserOptions.EXPERIMENTAL_useProjectService` no longer works on typescript-eslint v8.

The PR adds `delete parserOptions.useProjectService`. When `typescript-eslint` v8 becomes stable, we might want to adapt https://github.com/typescript-eslint/typescript-eslint/pull/9233 (https://github.com/typescript-eslint/typescript-eslint/issues/8428)