### PR TITLE
refactor: replace `dequal` w/ `stable-hash`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,13 +50,13 @@
   "dependencies": {
     "@typescript-eslint/utils": "^7.4.0",
     "debug": "^4.3.4",
-    "dequal": "^2.0.3",
     "doctrine": "^3.0.0",
     "eslint-import-resolver-node": "^0.3.9",
     "get-tsconfig": "^4.7.3",
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.3",
     "semver": "^7.6.0",
+    "stable-hash": "^0.0.4",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -1106,11 +1106,13 @@ function childContext(
 function makeContextCacheKey(context: RuleContext | ChildContext) {
   const { settings, parserPath, parserOptions, languageOptions } = context
 
-  let hash = stableHash(settings)
-    + stableHash(languageOptions?.parserOptions ?? parserOptions)
+  let hash =
+    stableHash(settings) +
+    stableHash(languageOptions?.parserOptions ?? parserOptions)
 
   if (languageOptions) {
-    hash += String(languageOptions.ecmaVersion) + String(languageOptions.sourceType)
+    hash +=
+      String(languageOptions.ecmaVersion) + String(languageOptions.sourceType)
   }
 
   hash += stableHash(

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -3,13 +3,13 @@ import path from 'node:path'
 
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import debug from 'debug'
-import { dequal } from 'dequal'
 import type { Annotation } from 'doctrine'
 import doctrine from 'doctrine'
 import type { AST } from 'eslint'
 import { SourceCode } from 'eslint'
 import type { TsConfigJsonResolved } from 'get-tsconfig'
 import { getTsconfig } from 'get-tsconfig'
+import stableHash from 'stable-hash'
 
 import type {
   ChildContext,
@@ -1105,24 +1105,25 @@ function childContext(
 
 type OptionsVersionsCache = Record<
   'settings' | 'parserOptions' | 'parser',
-  { value: unknown; version: number }
+  { value: unknown; hash: string }
 >
 
 const optionsVersionsCache: OptionsVersionsCache = {
-  settings: { value: null, version: 0 },
-  parserOptions: { value: null, version: 0 },
-  parser: { value: null, version: 0 },
+  settings: { value: null, hash: '' },
+  parserOptions: { value: null, hash: '' },
+  parser: { value: null, hash: '' },
 }
 
 function getOptionsVersion(key: keyof OptionsVersionsCache, value: unknown) {
   const entry = optionsVersionsCache[key]
+  const newHash = stableHash(value)
 
-  if (!dequal(value, entry.value)) {
+  if (newHash !== entry.hash) {
     entry.value = value
-    entry.version += 1
+    entry.hash = newHash
   }
 
-  return String(entry.version)
+  return newHash
 }
 
 function makeContextCacheKey(context: RuleContext | ChildContext) {

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -1103,45 +1103,17 @@ function childContext(
   }
 }
 
-type OptionsVersionsCache = Record<
-  'settings' | 'parserOptions' | 'parser',
-  { value: unknown; hash: string }
->
-
-const optionsVersionsCache: OptionsVersionsCache = {
-  settings: { value: null, hash: '' },
-  parserOptions: { value: null, hash: '' },
-  parser: { value: null, hash: '' },
-}
-
-function getOptionsVersion(key: keyof OptionsVersionsCache, value: unknown) {
-  const entry = optionsVersionsCache[key]
-  const newHash = stableHash(value)
-
-  if (newHash !== entry.hash) {
-    entry.value = value
-    entry.hash = newHash
-  }
-
-  return newHash
-}
-
 function makeContextCacheKey(context: RuleContext | ChildContext) {
   const { settings, parserPath, parserOptions, languageOptions } = context
 
-  let hash = getOptionsVersion('settings', settings)
-
-  const usedParserOptions = languageOptions?.parserOptions ?? parserOptions
-
-  hash += getOptionsVersion('parserOptions', usedParserOptions)
+  let hash = stableHash(settings)
+    + stableHash(languageOptions?.parserOptions ?? parserOptions)
 
   if (languageOptions) {
-    const { ecmaVersion, sourceType } = languageOptions
-    hash += String(ecmaVersion) + String(sourceType)
+    hash += String(languageOptions.ecmaVersion) + String(languageOptions.sourceType)
   }
 
-  hash += getOptionsVersion(
-    'parser',
+  hash += stableHash(
     parserPath ?? languageOptions?.parser?.meta ?? languageOptions?.parser,
   )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6156,6 +6156,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+stable-hash@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.4.tgz#55ae7dadc13e4b3faed13601587cec41859b42f7"
+  integrity sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==
+
 stack-utils@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"


### PR DESCRIPTION
Continues from #85.

Unlike `dequal`, `stable-hash` uses shallow comparison and referential equality only (so mutable Object, Set, and Map won't have the same hash after mutation). And `stable-hash` outputs meaningful hash instead of version.

cc @kosmotema 