### PR TITLE
feat: add support for legacy settings

### DIFF
--- a/.changeset/polite-cycles-double.md
+++ b/.changeset/polite-cycles-double.md
@@ -1,5 +1,5 @@
 ---
-"eslint-plugin-import-x": patch
+"eslint-plugin-import-x": minor
 ---
 
 add support for legacy settings

--- a/.changeset/polite-cycles-double.md
+++ b/.changeset/polite-cycles-double.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+add support for legacy settings

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
 export const pluginName = 'import-x'
 
-export type PluginName = typeof pluginName
+export const plguinNameLegacy = 'import'
+
+export type PluginName = typeof pluginName | typeof plguinNameLegacy

--- a/src/utils/ignore.ts
+++ b/src/utils/ignore.ts
@@ -28,13 +28,15 @@ function validExtensions(context: ChildContext | RuleContext) {
 export function getFileExtensions(settings: PluginSettings) {
   // start with explicit JS-parsed extensions
   const exts = new Set<FileExtension>(
-    settings['import-x/extensions'] || ['.js'],
+    settings['import-x/extensions'] || settings['import/extensions'] || ['.js'],
   )
 
+  const parsers = settings['import-x/parsers'] || settings['import/parsers']
+
   // all alternate parser extensions are also valid
-  if ('import-x/parsers' in settings) {
-    for (const parser in settings['import-x/parsers']) {
-      const parserSettings = settings['import-x/parsers'][parser]
+  if (parsers) {
+    for (const parser in parsers) {
+      const parserSettings = parsers[parser]
       if (!Array.isArray(parserSettings)) {
         throw new TypeError(`"settings" for ${parser} must be an array`)
       }
@@ -57,7 +59,8 @@ export function ignore(
     return true
   }
 
-  const ignoreStrings = context.settings['import-x/ignore']
+  const ignoreStrings =
+    context.settings['import-x/ignore'] || context.settings['import/ignore']
 
   if (!ignoreStrings?.length) {
     return false

--- a/src/utils/import-type.ts
+++ b/src/utils/import-type.ts
@@ -16,7 +16,8 @@ function baseModule(name: string) {
 }
 
 function isInternalRegexMatch(name: string, settings: PluginSettings) {
-  const internalScope = settings?.['import-x/internal-regex']
+  const internalScope =
+    settings?.['import-x/internal-regex'] || settings?.['import/internal-regex']
   return internalScope && new RegExp(internalScope).test(name)
 }
 
@@ -34,7 +35,10 @@ export function isBuiltIn(
     return false
   }
   const base = baseModule(name)
-  const extras = (settings && settings['import-x/core-modules']) || []
+  const extras =
+    (settings &&
+      (settings['import-x/core-modules'] || settings['import/core-modules'])) ||
+    []
   return isBuiltin(base) || extras.includes(base)
 }
 
@@ -117,9 +121,8 @@ function isExternalPath(
     return true
   }
 
-  const folders = settings?.['import-x/external-module-folders'] || [
-    'node_modules',
-  ]
+  const folders = settings?.['import-x/external-module-folders'] ||
+    settings?.['import/external-module-folders'] || ['node_modules']
   return folders.some(folder => {
     const folderPath = path.resolve(packagePath, folder)
     const relativePath = path.relative(folderPath, filepath)

--- a/src/utils/module-cache.ts
+++ b/src/utils/module-cache.ts
@@ -40,7 +40,7 @@ export class ModuleCache {
   static getSettings(settings: PluginSettings) {
     const cacheSettings = {
       lifetime: 30, // seconds
-      ...settings['import-x/cache'],
+      ...(settings['import-x/cache'] || settings['import/cache']),
     }
 
     // parse infinity

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -129,7 +129,9 @@ function fullResolve(
   settings: PluginSettings,
 ) {
   // check if this is a bonus core module
-  const coreSet = new Set(settings['import-x/core-modules'])
+  const coreSet = new Set(
+    settings['import-x/core-modules'] || settings['import/core-modules'],
+  )
   if (coreSet.has(modulePath)) {
     return {
       found: true,
@@ -181,8 +183,11 @@ function fullResolve(
   }
 
   const configResolvers = settings['import-x/resolver'] || {
-    node: settings['import-x/resolve'],
-  } // backward compatibility
+      node: settings['import-x/resolve'],
+    } ||
+    settings['import/resolver'] || {
+      node: settings['import/resolve'],
+    } // backward compatibility
 
   const resolvers = resolverReducer(configResolvers, new Map())
 


### PR DESCRIPTION
ESLint 9 allows us to custom the prefix of rules,

```js
{
      plugins: {
        'import': pluginImportX,
      },
      rules: {
          'import/no-unresolved': 'off'
      }
}
```

So we can get it fully compat with legacy import plugin configs.