### PR TITLE
feat: Add `ignoreUnusedTypeExports` option to `no-unused-modules`

### DIFF
--- a/.changeset/hot-fireants-provide.md
+++ b/.changeset/hot-fireants-provide.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": minor
+---
+
+Add `ignoreUnusedTypeExports` option to `no-unused-modules`

--- a/docs/rules/no-unused-modules.md
+++ b/docs/rules/no-unused-modules.md
@@ -29,6 +29,7 @@ This rule takes the following option:
 
 - **`missingExports`**: if `true`, files without any exports are reported (defaults to `false`)
 - **`unusedExports`**: if `true`, exports without any static usage within other modules are reported (defaults to `false`)
+- **`ignoreUnusedTypeExports`**: if `true`, TypeScript type exports without any static usage within other modules are reported (defaults to `false` and has no effect unless `unusedExports` is `true`)
 - `src`: an array with files/paths to be analyzed. It only applies to unused exports. Defaults to `process.cwd()`, if not provided
 - `ignoreExports`: an array with files/paths for which unused exports will not be reported (e.g module entry points in a published package)
 
@@ -118,6 +119,16 @@ export function doAnything() {
 } // will not be reported
 
 export default 5 // will not be reported
+```
+
+### Unused exports with `ignoreUnusedTypeExports` set to `true`
+
+The following will not be reported:
+
+```ts
+export type Foo = {}; // will not be reported
+export interface Foo = {}; // will not be reported
+export enum Foo {}; // will not be reported
 ```
 
 #### Important Note

--- a/test/rules/no-unused-modules.spec.ts
+++ b/test/rules/no-unused-modules.spec.ts
@@ -38,6 +38,15 @@ const unusedExportsTypescriptOptions = [
   },
 ]
 
+const unusedExportsTypescriptIgnoreUnusedTypesOptions = [
+  {
+    unusedExports: true,
+    ignoreUnusedTypeExports: true,
+    src: [testFilePath('./no-unused-modules/typescript')],
+    ignoreExports: undefined,
+  },
+]
+
 const unusedExportsJsxOptions = [
   {
     unusedExports: true,
@@ -1329,6 +1338,66 @@ describe('TypeScript', () => {
         ],
       }),
     ],
+  })
+})
+
+describe('ignoreUnusedTypeExports', () => {
+  const parser = parsers.TS
+
+  typescriptRuleTester.run('no-unused-modules', rule, {
+    valid: [
+      // unused vars should not report
+      test({
+        options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+        code: `export interface c {};`,
+        parser,
+        filename: testFilePath(
+          './no-unused-modules/typescript/file-ts-c-unused.ts',
+        ),
+      }),
+      test({
+        options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+        code: `export type d = {};`,
+        parser,
+        filename: testFilePath(
+          './no-unused-modules/typescript/file-ts-d-unused.ts',
+        ),
+      }),
+      test({
+        options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+        code: `export enum e { f };`,
+        parser,
+        filename: testFilePath(
+          './no-unused-modules/typescript/file-ts-e-unused.ts',
+        ),
+      }),
+      // used vars should not report
+      test({
+        options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+        code: `export interface c {};`,
+        parser,
+        filename: testFilePath(
+          './no-unused-modules/typescript/file-ts-c-used-as-type.ts',
+        ),
+      }),
+      test({
+        options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+        code: `export type d = {};`,
+        parser,
+        filename: testFilePath(
+          './no-unused-modules/typescript/file-ts-d-used-as-type.ts',
+        ),
+      }),
+      test({
+        options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+        code: `export enum e { f };`,
+        parser,
+        filename: testFilePath(
+          './no-unused-modules/typescript/file-ts-e-used-as-type.ts',
+        ),
+      }),
+    ],
+    invalid: [],
   })
 })
 


### PR DESCRIPTION
Direct port of https://github.com/import-js/eslint-plugin-import/pull/3011.

Fixes: https://github.com/un-ts/eslint-plugin-import-x/issues/86.