### PR TITLE
refactor: isolate parsing w/ typescript-eslint v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint": "^8.57.0 || ^9.0.0"
   },
   "dependencies": {
+    "@typescript-eslint/typescript-estree": "^8.1.0",
     "@typescript-eslint/utils": "^8.1.0",
     "debug": "^4.3.4",
     "doctrine": "^3.0.0",

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import { withoutProjectParserOptions } from '@typescript-eslint/typescript-estree'
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import debug from 'debug'
 
 import type {
@@ -86,7 +86,9 @@ export function parse(
   // https://github.com/eslint/eslint/blob/3ec436ee/lib/linter.js#L637
   parserOptions.filePath = path
 
-  parserOptions = withoutProjectParserOptions(parserOptions) as TSESLint.ParserOptions
+  parserOptions = withoutProjectParserOptions(
+    parserOptions,
+  ) as TSESLint.ParserOptions
 
   // @typescript-eslint/parser will parse the entire project with typechecking if you provide
   // "project" or "projects" in parserOptions. Removing these options means the parser will

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -86,14 +86,13 @@ export function parse(
   // https://github.com/eslint/eslint/blob/3ec436ee/lib/linter.js#L637
   parserOptions.filePath = path
 
-  parserOptions = withoutProjectParserOptions(
-    parserOptions,
-  ) as TSESLint.ParserOptions
-
   // @typescript-eslint/parser will parse the entire project with typechecking if you provide
   // "project" or "projects" in parserOptions. Removing these options means the parser will
   // only parse one file in isolate mode, which is much, much faster.
   // https://github.com/import-js/eslint-plugin-import/issues/1408#issuecomment-509298962
+  parserOptions = withoutProjectParserOptions(
+    parserOptions,
+  ) as TSESLint.ParserOptions
 
   // require the parser relative to the main module (i.e., ESLint)
   const parser =

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
+import { withoutProjectParserOptions } from '@typescript-eslint/typescript-estree'
 import debug from 'debug'
 
 import type {
@@ -85,17 +86,12 @@ export function parse(
   // https://github.com/eslint/eslint/blob/3ec436ee/lib/linter.js#L637
   parserOptions.filePath = path
 
+  parserOptions = withoutProjectParserOptions(parserOptions) as TSESLint.ParserOptions
+
   // @typescript-eslint/parser will parse the entire project with typechecking if you provide
   // "project" or "projects" in parserOptions. Removing these options means the parser will
   // only parse one file in isolate mode, which is much, much faster.
   // https://github.com/import-js/eslint-plugin-import/issues/1408#issuecomment-509298962
-
-  // TODO: prefer https://github.com/typescript-eslint/typescript-eslint/pull/9233 when typescript-eslint v8
-  // become stable
-  delete parserOptions.EXPERIMENTAL_useProjectService
-  delete parserOptions.projectService
-  delete parserOptions.project
-  delete parserOptions.projects
 
   // require the parser relative to the main module (i.e., ESLint)
   const parser =

--- a/yarn.lock
+++ b/yarn.lock
@@ -2641,7 +2641,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@8.1.0":
+"@typescript-eslint/typescript-estree@8.1.0", "@typescript-eslint/typescript-estree@^8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.1.0.tgz#c44e5667683c0bb5caa43192e27de6a994f4e4c4"
   integrity sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==


### PR DESCRIPTION
Use `withoutProjectParserOptions` from `@typescript-eslint/typescript-estree`.

Follows #93. See also https://github.com/typescript-eslint/typescript-eslint/pull/9233, https://github.com/typescript-eslint/typescript-eslint/issues/8428