### PR TITLE
feat: whitelist option for no-extraneous-dependencies

### DIFF
--- a/.changeset/light-apples-rhyme.md
+++ b/.changeset/light-apples-rhyme.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": minor
+---
+
+Add new option "whitelist" for rule "no-extraneous-dependencies"

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -9,7 +9,7 @@ Modules have to be installed for this rule to work.
 
 ## Options
 
-This rule supports the following options:
+### Dependency Options
 
 `devDependencies`: If set to `false`, then the rule will show an error when `devDependencies` are imported. Defaults to `true`.
 Type imports are ignored by default.
@@ -34,27 +34,41 @@ You can also use an array of globs instead of literal booleans:
 
 When using an array of globs, the setting will be set to `true` (no errors reported) if the name of the file being linted (i.e. not the imported file/module) matches a single glob in the array, and `false` otherwise.
 
+### Other Options
+
+#### `includeInternal` & `includeTypes`
+
 There are 2 boolean options to opt into checking extra imports that are normally ignored: `includeInternal`, which enables the checking of internal modules, and `includeTypes`, which enables checking of type imports in TypeScript.
 
 ```js
 "import-x/no-extraneous-dependencies": ["error", {"includeInternal": true, "includeTypes": true}]
 ```
 
-Also there is one more option called `packageDir`, this option is to specify the path to the folder containing package.json.
+#### `packageDir`
+
+The `packageDir` option is to specify the path to the folder containing package.json.
 
 If provided as a relative path string, will be computed relative to the current working directory at linter execution time. If this is not ideal (does not work with some editor integrations), consider using `__dirname` to provide a path relative to your configuration.
 
 ```js
-"import-x/no-extraneous-dependencies": ["error", {"packageDir": './some-dir/'}]
+"import-x/no-extraneous-dependencies": ["error", {"packageDir": "./some-dir/"}]
 // or
-"import-x/no-extraneous-dependencies": ["error", {"packageDir": path.join(__dirname, 'some-dir')}]
+"import-x/no-extraneous-dependencies": ["error", {"packageDir": path.join(__dirname, "some-dir")}]
 ```
 
 It may also be an array of multiple paths, to support monorepos or other novel project
 folder layouts:
 
 ```js
-"import-x/no-extraneous-dependencies": ["error", {"packageDir": ['./some-dir/', './root-pkg']}]
+"import-x/no-extraneous-dependencies": ["error", {"packageDir": ["./some-dir/", "./root-pkg"]}]
+```
+
+#### `whitelist`
+
+The `whitelist` option is an optional string array to specify the names of packages that this rule should ignore.
+
+```js
+"import-x/no-extraneous-dependencies": ["error", {"whitelist": ["foo", "bar"]}]
 ```
 
 ## Rule Details

--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -215,6 +215,7 @@ function reportIfMissing(
   depsOptions: DepsOptions,
   node: TSESTree.Node,
   name: string,
+  whitelist: string[],
 ) {
   // Do not report when importing types unless option is enabled
   if (
@@ -292,6 +293,10 @@ function reportIfMissing(
 
   const packageName = realPackageName || importPackageName
 
+  if (whitelist.includes(packageName)) {
+    return;
+  }
+
   if (declarationStatus.isInDevDeps && !depsOptions.allowDevDeps) {
     context.report({
       node,
@@ -342,6 +347,7 @@ type Options = {
   bundledDependencies?: boolean
   includeInternal?: boolean
   includeTypes?: boolean
+  whitelist?: string[]
 }
 
 type MessageId =
@@ -405,10 +411,12 @@ export = createRule<[Options?], MessageId>({
       verifyTypeImports: !!options.includeTypes,
     }
 
+    const whitelist = options.whitelist ?? [];
+
     return {
       ...moduleVisitor(
         (source, node) => {
-          reportIfMissing(context, deps, depsOptions, node, source.value)
+          reportIfMissing(context, deps, depsOptions, node, source.value, whitelist)
         },
         { commonjs: true },
       ),

--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -376,6 +376,7 @@ export = createRule<[Options?], MessageId>({
           packageDir: { type: ['string', 'array'] },
           includeInternal: { type: ['boolean'] },
           includeTypes: { type: ['boolean'] },
+          whitelist: { type: ['array'] },
         },
         additionalProperties: false,
       },

--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -416,7 +416,14 @@ export = createRule<[Options?], MessageId>({
     return {
       ...moduleVisitor(
         (source, node) => {
-          reportIfMissing(context, deps, depsOptions, node, source.value, whitelist)
+          reportIfMissing(
+            context,
+            deps,
+            depsOptions,
+            node,
+            source.value,
+            whitelist,
+          )
         },
         { commonjs: true },
       ),

--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -215,7 +215,7 @@ function reportIfMissing(
   depsOptions: DepsOptions,
   node: TSESTree.Node,
   name: string,
-  whitelist: string[],
+  whitelist: Set<string> | undefined,
 ) {
   // Do not report when importing types unless option is enabled
   if (
@@ -293,7 +293,7 @@ function reportIfMissing(
 
   const packageName = realPackageName || importPackageName
 
-  if (whitelist.includes(packageName)) {
+  if (whitelist?.has(packageName)) {
     return
   }
 
@@ -411,8 +411,6 @@ export = createRule<[Options?], MessageId>({
       verifyTypeImports: !!options.includeTypes,
     }
 
-    const whitelist = options.whitelist ?? []
-
     return {
       ...moduleVisitor(
         (source, node) => {
@@ -422,7 +420,7 @@ export = createRule<[Options?], MessageId>({
             depsOptions,
             node,
             source.value,
-            whitelist,
+            options.whitelist ? new Set(options.whitelist) : undefined,
           )
         },
         { commonjs: true },

--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -294,7 +294,7 @@ function reportIfMissing(
   const packageName = realPackageName || importPackageName
 
   if (whitelist.includes(packageName)) {
-    return;
+    return
   }
 
   if (declarationStatus.isInDevDeps && !depsOptions.allowDevDeps) {
@@ -411,7 +411,7 @@ export = createRule<[Options?], MessageId>({
       verifyTypeImports: !!options.includeTypes,
     }
 
-    const whitelist = options.whitelist ?? [];
+    const whitelist = options.whitelist ?? []
 
     return {
       ...moduleVisitor(

--- a/test/rules/no-extraneous-dependencies.spec.ts
+++ b/test/rules/no-extraneous-dependencies.spec.ts
@@ -224,7 +224,9 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({
       code: 'import "not-a-dependency"',
       filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
-      options: [{ packageDir: packageDirMonoRepoRoot, whitelist: ["not-a-dependency"] }],
+      options: [
+        { packageDir: packageDirMonoRepoRoot, whitelist: ['not-a-dependency'] },
+      ],
     }),
   ],
   invalid: [

--- a/test/rules/no-extraneous-dependencies.spec.ts
+++ b/test/rules/no-extraneous-dependencies.spec.ts
@@ -220,6 +220,12 @@ ruleTester.run('no-extraneous-dependencies', rule, {
         },
       },
     }),
+
+    test({
+      code: 'import "not-a-dependency"',
+      filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
+      options: [{ packageDir: packageDirMonoRepoRoot, whitelist: ["not-a-dependency"] }],
+    }),
   ],
   invalid: [
     test({


### PR DESCRIPTION
Closes #141.

This PR also includes some typo fixes in "no-extraneous-dependencies.md".

Also note that I had some difficulties in setting up this repo. After a clone, I typed "yarn" to install the project dependencies. Then, "npm run build" succeeded, but "npm run test" and "npm run lint" both failed from a completely fresh repo. Is that expected?