### PR TITLE
ci: use `matrix.include` to set data for optional steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
           - '8.56'
           - '8'
           - '9'
+
+        include:
+          - executeLint: true
+            node: 20
+            os: ubuntu-latest
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
@@ -65,7 +71,7 @@ jobs:
           EFF_NO_LINK_RULES: true
           PARSER_NO_WATCH: true
           SKIP_YARN_COREPACK_CHECK: 1
-        if: ${{ matrix.node == 20 }}
+        if: ${{ matrix.executeLint }}
 
       - name: Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
I made a small improvement to the `ci` workflow.
Using `matrix.include` feature I integrate the configuration matrix with two values:

### 1. `matrix.executeLint`

It controls the execution of `Lint` step. The behaviour should remain the same.

### 2. `matrix.executeCoverage`

Instead of running coverage on each matrix combination I have limited it only to the node 20 combination.

---

> [!NOTE]
> The main advantage is that  the control value of steps execution is located near the matrix values,
> so they can be updated more easily.

> [!TIP]
> More information about this feature can be found on [GitHub Actions documentation reference](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#expanding-or-adding-matrix-configurations).