### PR TITLE
fix(`no-unused-modules`): default `src` to `process.cwd()` again

### DIFF
--- a/.changeset/flat-doors-chew.md
+++ b/.changeset/flat-doors-chew.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+Fix regression in rule `no-unused-modules` which would incorrectly initialize option `src` to `[]` instead of `[process.cwd()]`, breaking file discovery.

--- a/src/rules/no-unused-modules.ts
+++ b/src/rules/no-unused-modules.ts
@@ -291,13 +291,6 @@ const determineUsage = () => {
   }
 }
 
-const getSrc = (src?: string[]) => {
-  if (src) {
-    return src
-  }
-  return [process.cwd()]
-}
-
 /**
  * prepare the lists of existing imports and exports - should only be executed once at
  * the start of a new eslint run
@@ -306,7 +299,7 @@ let srcFiles: Set<string>
 let lastPrepareKey: string
 
 const doPreparation = (
-  src: string[] = [],
+  src: string[],
   ignoreExports: string[],
   context: RuleContext,
 ) => {
@@ -324,7 +317,7 @@ const doPreparation = (
   ignoredFiles.clear()
   filesOutsideSrc.clear()
 
-  srcFiles = resolveFiles(getSrc(src), ignoreExports, context)
+  srcFiles = resolveFiles(src, ignoreExports, context)
   prepareImportsAndExports(srcFiles, context)
   determineUsage()
   lastPrepareKey = prepareKey
@@ -486,7 +479,7 @@ export = createRule<Options[], MessageId>({
   defaultOptions: [],
   create(context) {
     const {
-      src,
+      src = [process.cwd()],
       ignoreExports = [],
       missingExports,
       unusedExports,
@@ -559,7 +552,7 @@ export = createRule<Options[], MessageId>({
 
       // make sure file to be linted is included in source files
       if (!srcFiles.has(filename)) {
-        srcFiles = resolveFiles(getSrc(src), ignoreExports, context)
+        srcFiles = resolveFiles(src, ignoreExports, context)
         if (!srcFiles.has(filename)) {
           filesOutsideSrc.add(filename)
           return


### PR DESCRIPTION
Fix initialization of option `src` to again default to `process.cwd()` per [the documentation](https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-unused-modules.md#options).

de896f46b1e3d3bcc51015d2e0269e6ae80dc87d (released in v0.3.1) added an incorrect [default parameter value of `[]` for `src`](https://github.com/un-ts/eslint-plugin-import-x/blob/master/src/rules/no-unused-modules.ts#L309). This introduced a regression that breaks discovery of source files unless option `src` is explicitly set by the consumer, resulting in false positives for `unusedExports`.