### PR TITLE
Fix incorrect no-duplicates prefer-inline default type import handling

### DIFF
--- a/.changeset/mighty-ladybugs-agree.md
+++ b/.changeset/mighty-ladybugs-agree.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-import-x': patch
+---
+
+Fix issue where `no-duplicates` rule with `prefer-inline` incorrectly marks default type and named type imports as duplicates

--- a/src/rules/no-duplicates.ts
+++ b/src/rules/no-duplicates.ts
@@ -463,12 +463,16 @@ export = createRule<[Options?], MessageId>({
         moduleMaps.set(parent, map)
       }
 
-      if (!preferInline && n.importKind === 'type') {
-        return n.specifiers.length > 0 &&
-          n.specifiers[0].type === 'ImportDefaultSpecifier'
-          ? map.defaultTypesImported
-          : map.namedTypesImported
+      if (n.importKind === 'type') {
+        if (n.specifiers.length > 0 && n.specifiers[0].type === 'ImportDefaultSpecifier') {
+          return map.defaultTypesImported;
+        }
+
+        if (!preferInline) {
+          return map.namedTypesImported;
+        }
       }
+
       if (
         !preferInline &&
         n.specifiers.some(

--- a/src/rules/no-duplicates.ts
+++ b/src/rules/no-duplicates.ts
@@ -464,12 +464,15 @@ export = createRule<[Options?], MessageId>({
       }
 
       if (n.importKind === 'type') {
-        if (n.specifiers.length > 0 && n.specifiers[0].type === 'ImportDefaultSpecifier') {
-          return map.defaultTypesImported;
+        if (
+          n.specifiers.length > 0 &&
+          n.specifiers[0].type === 'ImportDefaultSpecifier'
+        ) {
+          return map.defaultTypesImported
         }
 
         if (!preferInline) {
-          return map.namedTypesImported;
+          return map.namedTypesImported
         }
       }
 

--- a/test/rules/no-duplicates.spec.ts
+++ b/test/rules/no-duplicates.spec.ts
@@ -692,6 +692,11 @@ describe('TypeScript', () => {
       ...parserConfig,
       options: [{ 'prefer-inline': true }],
     }),
+    test({
+      code: "import type A from 'foo';import { B } from 'foo';",
+      ...parserConfig,
+      options: [{ 'prefer-inline': true }],
+    }),
   ]
 
   const invalid = [

--- a/test/rules/no-duplicates.spec.ts
+++ b/test/rules/no-duplicates.spec.ts
@@ -682,6 +682,16 @@ describe('TypeScript', () => {
             ...parserConfig,
           }),
         ]),
+    test({
+      code: "import type { A } from 'foo';import type B from 'foo';",
+      ...parserConfig,
+      options: [{ 'prefer-inline': true }],
+    }),
+    test({
+      code: "import { type A } from 'foo';import type B from 'foo';",
+      ...parserConfig,
+      options: [{ 'prefer-inline': true }],
+    }),
   ]
 
   const invalid = [


### PR DESCRIPTION
I ran into this issue in one of my repositories with Koa:

```typescript
import { type Middleware } from 'koa';
import type Koa from 'koa';
```

The rule was rewriting it to invalid syntax:

```typescript
import Koa, type { Middleware } from 'koa';
```

One approach could be just to allow it to:

```typescript
import Koa, { type Middleware } from 'koa';
```

However, I don't think this plugin should be changing type imports into value imports in this scenario.
Therefore, after this change, it leaves the imports alone. I hope this should be not too controversial given it was previously producing invalid syntax. 

I am of course not an expert in this code :) but the change seems suspiciously simple. Are there any additional test cases I can add to help verify this? 