### PR TITLE
`extensions`: added `checkTypeImports` option

### DIFF
--- a/.changeset/tidy-crews-sit.md
+++ b/.changeset/tidy-crews-sit.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": minor
+---
+
+Add new rule option `checkTypedImports` for `extensions`, backports https://github.com/import-js/eslint-plugin-import/pull/2817

--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -56,6 +56,8 @@ For example, `["error", "never", { "svg": "always" }]` would require that all ex
 In that case, if you still want to specify extensions, you can do so inside the **pattern** property.
 Default value of `ignorePackages` is `false`.
 
+By default, `import type` and `export type` style imports/exports are ignored. If you want to check them as well, you can set the `checkTypeImports` option to `true`.
+
 ### Exception
 
 When disallowing the use of certain extensions this rule makes an exception and allows the use of extension when the file would not be resolvable without extension.
@@ -102,6 +104,13 @@ import Component from './Component'
 import express from 'express/index'
 
 import * as path from 'path'
+```
+
+The following patterns are considered problems when the configuration is set to "never" and the option "checkTypeImports" is set to `true`:
+
+```js
+import type { Foo } from './foo.ts';
+export type { Foo } from './foo.ts';
 ```
 
 The following patterns are considered problems when configuration set to "always":
@@ -164,6 +173,13 @@ import baz from 'foo/baz.js'
 import express from 'express'
 
 import foo from '@/foo'
+```
+
+The following patterns are considered problems when the configuration is set to "always" and the option "checkTypeImports" is set to `true`:
+
+```js
+import type { Foo } from './foo';
+export type { Foo } from './foo';
 ```
 
 ## When Not To Use It

--- a/test/rules/extensions.spec.ts
+++ b/test/rules/extensions.spec.ts
@@ -5,6 +5,15 @@ import { test, testFilePath } from '../utils'
 import rule from 'eslint-plugin-import-x/rules/extensions'
 
 const ruleTester = new TSESLintRuleTester()
+const ruleTesterWithTypeScriptImports = new TSESLintRuleTester({
+  settings: {
+    'import/resolver': {
+      typescript: {
+        alwaysTryTypes: true,
+      },
+    },
+  },
+})
 
 ruleTester.run('extensions', rule, {
   valid: [
@@ -693,6 +702,58 @@ describe('TypeScript', () => {
           'always',
           { ts: 'never', tsx: 'never', js: 'never', jsx: 'never' },
         ],
+      }),
+      test({
+        code: 'import type T from "./typescript-declare";',
+        errors: ['Missing file extension for "./typescript-declare"'],
+        options: [
+          'always',
+          {
+            ts: 'never',
+            tsx: 'never',
+            js: 'never',
+            jsx: 'never',
+            checkTypeImports: true,
+          },
+        ],
+      }),
+      test({
+        code: 'export type { MyType } from "./typescript-declare";',
+        errors: ['Missing file extension for "./typescript-declare"'],
+        options: [
+          'always',
+          {
+            ts: 'never',
+            tsx: 'never',
+            js: 'never',
+            jsx: 'never',
+            checkTypeImports: true,
+          },
+        ],
+      }),
+    ],
+  })
+  ruleTesterWithTypeScriptImports.run('extensions', rule, {
+    valid: [
+      test({
+        code: 'import type { MyType } from "./typescript-declare.ts";',
+        options: ['always', { checkTypeImports: true }],
+      }),
+      test({
+        code: 'export type { MyType } from "./typescript-declare.ts";',
+        options: ['always', { checkTypeImports: true }],
+      }),
+    ],
+    invalid: [
+      test({
+        code: 'import type { MyType } from "./typescript-declare";',
+        errors: ['Missing file extension for "./typescript-declare"'],
+        options: ['always', { checkTypeImports: true }],
+      }),
+      test({
+        code: 'export type { MyType } from "./typescript-declare";',
+        errors: ['Missing file extension for "./typescript-declare"'],
+        options: ['always', { checkTypeImports: true }],
       }),
     ],
   })


### PR DESCRIPTION
upstream has implemented this in https://github.com/import-js/eslint-plugin-import/commit/d225176343d491db07a1c9e6e521ea90f169c928

basically ported the feature and test cases from there

idk how to add this to changelog, would be nice if someone did that for me :>