### PR TITLE
fix(no-extraneous-dependencies): correct some `Options` type properties

### DIFF
--- a/.changeset/witty-apples-chew.md
+++ b/.changeset/witty-apples-chew.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix(no-extraneous-dependencies): correct some `Options` type properties

--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -341,10 +341,10 @@ function testConfig(config: string[] | boolean | undefined, filename: string) {
 
 type Options = {
   packageDir?: string | string[]
-  devDependencies?: boolean
-  optionalDependencies?: boolean
-  peerDependencies?: boolean
-  bundledDependencies?: boolean
+  devDependencies?: boolean | string[]
+  optionalDependencies?: boolean | string[]
+  peerDependencies?: boolean | string[]
+  bundledDependencies?: boolean | string[]
   includeInternal?: boolean
   includeTypes?: boolean
   whitelist?: string[]


### PR DESCRIPTION
`no-extraneous-dependencies` rule `Options` type contains incorrect definition for the following properties:

- `devDependencies`
- `optionalDependencies`
- `peerDependencies`
- `bundledDependencies`

They should be `boolean | string[]` as stated in the rule schema below:

https://github.com/un-ts/eslint-plugin-import-x/blob/3a4517031a15303733589c8441d00233fd568abc/src/rules/no-extraneous-dependencies.ts#L372-L375