### PR TITLE
fix(extensions): correct `Options` type

### DIFF
--- a/.changeset/polite-snakes-buy.md
+++ b/.changeset/polite-snakes-buy.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix(extensions): correct `Options` type


### PR DESCRIPTION
Refine `extensions` rule  `Options`:

- since the function used by the rule to get file extension is called is called `getModifier` I renamed all relevant information using `modifier` name.
- Refined `Options` with more explicit array types
- Changed `buildProperties` checks to avoid type checking errors

