### PR TITLE
test: create utility function to infer rule types

### DIFF
--- a/test/rules/no-useless-path-segments.spec.ts
+++ b/test/rules/no-useless-path-segments.spec.ts
@@ -1,8 +1,10 @@
 import { RuleTester as TSESLintRuleTester } from '@typescript-eslint/rule-tester'
 
-import { parsers, test } from '../utils'
+import { parsers, createRuleTestCaseFunction } from '../utils'
 
 import rule from 'eslint-plugin-import-x/rules/no-useless-path-segments'
+
+const test = createRuleTestCaseFunction<typeof rule>()
 
 const ruleTester = new TSESLintRuleTester()
 
@@ -74,7 +76,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         options: [{ commonjs: true }],
         languageOptions: { parser: require(parsers.ESPREE) },
         errors: [
-          'Useless path segments for "./../fixtures/malformed.js", should be "../fixtures/malformed.js"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './../fixtures/malformed.js',
+              proposedPath: '../fixtures/malformed.js',
+            },
+          },
         ],
       }),
       test({
@@ -83,7 +91,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         options: [{ commonjs: true }],
         languageOptions: { parser: require(parsers.ESPREE) },
         errors: [
-          'Useless path segments for "./../fixtures/malformed", should be "../fixtures/malformed"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './../fixtures/malformed',
+              proposedPath: '../fixtures/malformed',
+            },
+          },
         ],
       }),
       test({
@@ -92,7 +106,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         options: [{ commonjs: true }],
         languageOptions: { parser: require(parsers.BABEL) },
         errors: [
-          'Useless path segments for "../fixtures/malformed.js", should be "./malformed.js"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: '../fixtures/malformed.js',
+              proposedPath: './malformed.js',
+            },
+          },
         ],
       }),
       test({
@@ -101,7 +121,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         options: [{ commonjs: true }],
         languageOptions: { parser: require(parsers.ESPREE) },
         errors: [
-          'Useless path segments for "../fixtures/malformed", should be "./malformed"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: '../fixtures/malformed',
+              proposedPath: './malformed',
+            },
+          },
         ],
       }),
       test({
@@ -110,26 +136,47 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         options: [{ commonjs: true }],
         languageOptions: { parser: require(parsers.ESPREE) },
         errors: [
-          'Useless path segments for "./test-module/", should be "./test-module"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './test-module/',
+              proposedPath: './test-module',
+            },
+          },
         ],
       }),
       test({
         code: 'require("./")',
         output: 'require(".")',
         options: [{ commonjs: true }],
-        errors: ['Useless path segments for "./", should be "."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './', proposedPath: '.' },
+          },
+        ],
       }),
       test({
         code: 'require("../")',
         output: 'require("..")',
         options: [{ commonjs: true }],
-        errors: ['Useless path segments for "../", should be ".."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: '../', proposedPath: '..' },
+          },
+        ],
       }),
       test({
         code: 'require("./deep//a")',
         output: 'require("./deep/a")',
         options: [{ commonjs: true }],
-        errors: ['Useless path segments for "./deep//a", should be "./deep/a"'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './deep//a', proposedPath: './deep/a' },
+          },
+        ],
       }),
 
       // CommonJS modules + noUselessIndex
@@ -138,21 +185,32 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: 'require("./bar/")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: [
-          'Useless path segments for "./bar/index.js", should be "./bar/"',
+          {
+            messageId: 'useless',
+            data: { importPath: './bar/index.js', proposedPath: './bar/' },
+          },
         ], // ./bar.js exists
       }),
       test({
         code: 'require("./bar/index")',
         output: 'require("./bar/")',
         options: [{ commonjs: true, noUselessIndex: true }],
-        errors: ['Useless path segments for "./bar/index", should be "./bar/"'], // ./bar.js exists
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './bar/index', proposedPath: './bar/' },
+          },
+        ], // ./bar.js exists
       }),
       test({
         code: 'require("./importPath/")',
         output: 'require("./importPath")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: [
-          'Useless path segments for "./importPath/", should be "./importPath"',
+          {
+            messageId: 'useless',
+            data: { importPath: './importPath/', proposedPath: './importPath' },
+          },
         ], // ./importPath.js does not exist
       }),
       test({
@@ -160,7 +218,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: 'require("./importPath")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: [
-          'Useless path segments for "./importPath/index.js", should be "./importPath"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './importPath/index.js',
+              proposedPath: './importPath',
+            },
+          },
         ], // ./importPath.js does not exist
       }),
       test({
@@ -168,26 +232,47 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: 'require("./importType")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: [
-          'Useless path segments for "./importType/index", should be "./importType"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './importType/index',
+              proposedPath: './importType',
+            },
+          },
         ], // ./importPath.js does not exist
       }),
       test({
         code: 'require("./index")',
         output: 'require(".")',
         options: [{ commonjs: true, noUselessIndex: true }],
-        errors: ['Useless path segments for "./index", should be "."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './index', proposedPath: '.' },
+          },
+        ],
       }),
       test({
         code: 'require("../index")',
         output: 'require("..")',
         options: [{ commonjs: true, noUselessIndex: true }],
-        errors: ['Useless path segments for "../index", should be ".."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: '../index', proposedPath: '..' },
+          },
+        ],
       }),
       test({
         code: 'require("../index.js")',
         output: 'require("..")',
         options: [{ commonjs: true, noUselessIndex: true }],
-        errors: ['Useless path segments for "../index.js", should be ".."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: '../index.js', proposedPath: '..' },
+          },
+        ],
       }),
 
       // ES modules
@@ -199,7 +284,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         ],
         languageOptions: { parser: require(parsers.ESPREE) },
         errors: [
-          'Useless path segments for "./../fixtures/malformed.js", should be "../fixtures/malformed.js"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './../fixtures/malformed.js',
+              proposedPath: '../fixtures/malformed.js',
+            },
+          },
         ],
       }),
       test({
@@ -207,7 +298,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: ['import "../fixtures/malformed"', 'import "./malformed"'],
         languageOptions: { parser: require(parsers.ESPREE) },
         errors: [
-          'Useless path segments for "./../fixtures/malformed", should be "../fixtures/malformed"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './../fixtures/malformed',
+              proposedPath: '../fixtures/malformed',
+            },
+          },
         ],
       }),
       test({
@@ -215,7 +312,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: 'import "./malformed.js"',
         languageOptions: { parser: require(parsers.BABEL) },
         errors: [
-          'Useless path segments for "../fixtures/malformed.js", should be "./malformed.js"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: '../fixtures/malformed.js',
+              proposedPath: './malformed.js',
+            },
+          },
         ],
       }),
       test({
@@ -223,30 +326,57 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: 'import "./malformed"',
         languageOptions: { parser: require(parsers.ESPREE) },
         errors: [
-          'Useless path segments for "../fixtures/malformed", should be "./malformed"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: '../fixtures/malformed',
+              proposedPath: './malformed',
+            },
+          },
         ],
       }),
       test({
         code: 'import "./test-module/"',
         output: 'import "./test-module"',
         errors: [
-          'Useless path segments for "./test-module/", should be "./test-module"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './test-module/',
+              proposedPath: './test-module',
+            },
+          },
         ],
       }),
       test({
         code: 'import "./"',
         output: 'import "."',
-        errors: ['Useless path segments for "./", should be "."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './', proposedPath: '.' },
+          },
+        ],
       }),
       test({
         code: 'import "../"',
         output: 'import ".."',
-        errors: ['Useless path segments for "../", should be ".."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: '../', proposedPath: '..' },
+          },
+        ],
       }),
       test({
         code: 'import "./deep//a"',
         output: 'import "./deep/a"',
-        errors: ['Useless path segments for "./deep//a", should be "./deep/a"'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './deep//a', proposedPath: './deep/a' },
+          },
+        ],
       }),
 
       // ES modules + noUselessIndex
@@ -255,21 +385,32 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: 'import "./bar/"',
         options: [{ noUselessIndex: true }],
         errors: [
-          'Useless path segments for "./bar/index.js", should be "./bar/"',
+          {
+            messageId: 'useless',
+            data: { importPath: './bar/index.js', proposedPath: './bar/' },
+          },
         ], // ./bar.js exists
       }),
       test({
         code: 'import "./bar/index"',
         output: 'import "./bar/"',
         options: [{ noUselessIndex: true }],
-        errors: ['Useless path segments for "./bar/index", should be "./bar/"'], // ./bar.js exists
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './bar/index', proposedPath: './bar/' },
+          },
+        ], // ./bar.js exists
       }),
       test({
         code: 'import "./importPath/"',
         output: 'import "./importPath"',
         options: [{ noUselessIndex: true }],
         errors: [
-          'Useless path segments for "./importPath/", should be "./importPath"',
+          {
+            messageId: 'useless',
+            data: { importPath: './importPath/', proposedPath: './importPath' },
+          },
         ], // ./importPath.js does not exist
       }),
       test({
@@ -277,7 +418,13 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: 'import "./importPath"',
         options: [{ noUselessIndex: true }],
         errors: [
-          'Useless path segments for "./importPath/index.js", should be "./importPath"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './importPath/index.js',
+              proposedPath: './importPath',
+            },
+          },
         ], // ./importPath.js does not exist
       }),
       test({
@@ -285,44 +432,80 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         output: 'import "./importPath"',
         options: [{ noUselessIndex: true }],
         errors: [
-          'Useless path segments for "./importPath/index", should be "./importPath"',
+          {
+            messageId: 'useless',
+            data: {
+              importPath: './importPath/index',
+              proposedPath: './importPath',
+            },
+          },
         ], // ./importPath.js does not exist
       }),
       test({
         code: 'import "./index"',
         output: 'import "."',
         options: [{ noUselessIndex: true }],
-        errors: ['Useless path segments for "./index", should be "."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './index', proposedPath: '.' },
+          },
+        ],
       }),
       test({
         code: 'import "../index"',
         output: 'import ".."',
         options: [{ noUselessIndex: true }],
-        errors: ['Useless path segments for "../index", should be ".."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: '../index', proposedPath: '..' },
+          },
+        ],
       }),
       test({
         code: 'import "../index.js"',
         output: 'import ".."',
         options: [{ noUselessIndex: true }],
-        errors: ['Useless path segments for "../index.js", should be ".."'],
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: '../index.js', proposedPath: '..' },
+          },
+        ],
       }),
       test({
         code: 'import("./")',
         output: 'import(".")',
-        errors: ['Useless path segments for "./", should be "."'],
         languageOptions: { parser: require(parsers.BABEL) },
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './', proposedPath: '.' },
+          },
+        ],
       }),
       test({
         code: 'import("../")',
         output: 'import("..")',
-        errors: ['Useless path segments for "../", should be ".."'],
         languageOptions: { parser: require(parsers.BABEL) },
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: '../', proposedPath: '..' },
+          },
+        ],
       }),
       test({
         code: 'import("./deep//a")',
         output: 'import("./deep/a")',
-        errors: ['Useless path segments for "./deep//a", should be "./deep/a"'],
         languageOptions: { parser: require(parsers.BABEL) },
+        errors: [
+          {
+            messageId: 'useless',
+            data: { importPath: './deep//a', proposedPath: './deep/a' },
+          },
+        ],
       }),
     ],
   })

--- a/test/rules/no-webpack-loader-syntax.spec.ts
+++ b/test/rules/no-webpack-loader-syntax.spec.ts
@@ -1,12 +1,12 @@
 import { RuleTester as TSESLintRuleTester } from '@typescript-eslint/rule-tester'
 
-import { test } from '../utils'
+import { createRuleTestCaseFunction } from '../utils'
 
 import rule from 'eslint-plugin-import-x/rules/no-webpack-loader-syntax'
 
-const ruleTester = new TSESLintRuleTester()
+const test = createRuleTestCaseFunction<typeof rule>()
 
-const message = 'Do not use import syntax to configure webpack loaders.'
+const ruleTester = new TSESLintRuleTester()
 
 ruleTester.run('no-webpack-loader-syntax', rule, {
   valid: [
@@ -25,53 +25,57 @@ ruleTester.run('no-webpack-loader-syntax', rule, {
   invalid: [
     test({
       code: 'import _ from "babel!lodash"',
-      errors: [{ message: `Unexpected '!' in 'babel!lodash'. ${message}` }],
+      errors: [{ messageId: 'unexpected', data: { name: 'babel!lodash' } }],
     }),
     test({
       code: 'import find from "-babel-loader!lodash.find"',
       errors: [
         {
-          message: `Unexpected '!' in '-babel-loader!lodash.find'. ${message}`,
+          messageId: 'unexpected',
+          data: { name: '-babel-loader!lodash.find' },
         },
       ],
     }),
     test({
       code: 'import foo from "style!css!./foo.css"',
       errors: [
-        { message: `Unexpected '!' in 'style!css!./foo.css'. ${message}` },
+        { messageId: 'unexpected', data: { name: 'style!css!./foo.css' } },
       ],
     }),
     test({
       code: 'import data from "json!@scope/my-package/data.json"',
       errors: [
         {
-          message: `Unexpected '!' in 'json!@scope/my-package/data.json'. ${message}`,
+          messageId: 'unexpected',
+          data: { name: 'json!@scope/my-package/data.json' },
         },
       ],
     }),
     test({
       code: 'var _ = require("babel!lodash")',
-      errors: [{ message: `Unexpected '!' in 'babel!lodash'. ${message}` }],
+      errors: [{ messageId: 'unexpected', data: { name: 'babel!lodash' } }],
     }),
     test({
       code: 'var find = require("-babel-loader!lodash.find")',
       errors: [
         {
-          message: `Unexpected '!' in '-babel-loader!lodash.find'. ${message}`,
+          messageId: 'unexpected',
+          data: { name: '-babel-loader!lodash.find' },
         },
       ],
     }),
     test({
       code: 'var foo = require("style!css!./foo.css")',
       errors: [
-        { message: `Unexpected '!' in 'style!css!./foo.css'. ${message}` },
+        { messageId: 'unexpected', data: { name: 'style!css!./foo.css' } },
       ],
     }),
     test({
       code: 'var data = require("json!@scope/my-package/data.json")',
       errors: [
         {
-          message: `Unexpected '!' in 'json!@scope/my-package/data.json'. ${message}`,
+          messageId: 'unexpected',
+          data: { name: 'json!@scope/my-package/data.json' },
         },
       ],
     }),

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -70,6 +70,24 @@ export function testVersion<T extends ValidTestCase>(
   return eslintVersionSatisfies(specifier) ? [test(t())] : []
 }
 
+/** @warning DO NOT EXPORT THIS. use {@link createRuleTestCaseFunction} or {@link test} instead */
+function createRuleTestCase<TTestCase extends TSESLintValidTestCase<unknown[]>>(
+  t: TTestCase,
+): TTestCase {
+  return {
+    filename: TEST_FILENAME,
+    ...t,
+    languageOptions: {
+      ...t.languageOptions,
+      parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 9,
+        ...t.languageOptions?.parserOptions,
+      },
+    },
+  }
+}
+
 export type InvalidTestCaseError =
   | string
   | InvalidTestCase['errors'][number]
@@ -83,19 +101,8 @@ export function test<T extends ValidTestCase>(
 ): T extends { errors: InvalidTestCaseError[] | number }
   ? InvalidTestCase
   : ValidTestCase {
-  // @ts-expect-error -- simplify testing
-  return {
-    filename: TEST_FILENAME,
-    ...t,
-    languageOptions: {
-      ...t.languageOptions,
-      parserOptions: {
-        sourceType: 'module',
-        ecmaVersion: 9,
-        ...t.languageOptions?.parserOptions,
-      },
-    },
-  }
+  // @ts-expect-error simplify testing
+  return createRuleTestCase(t)
 }
 
 type GetRuleType<TRule> =
@@ -121,20 +128,8 @@ export function createRuleTestCaseFunction<
 >(
   t: TTestCase,
 ) => TReturn {
-  return t => {
-    return {
-      filename: TEST_FILENAME,
-      ...t,
-      languageOptions: {
-        ...t.languageOptions,
-        parserOptions: {
-          sourceType: 'module',
-          ecmaVersion: 9,
-          ...t.languageOptions?.parserOptions,
-        },
-      },
-    } as never
-  }
+  // @ts-expect-error simplify testing
+  return createRuleTestCase
 }
 
 export function testContext(settings?: PluginSettings) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -7,7 +7,6 @@ import type {
 import type { TSESTree } from '@typescript-eslint/utils'
 import type { RuleModule } from '@typescript-eslint/utils/ts-eslint'
 import type { RuleTester } from 'eslint'
-import eslintPkg from 'eslint/package.json'
 import semver from 'semver'
 import typescriptPkg from 'typescript/package.json'
 
@@ -46,10 +45,6 @@ export function getNonDefaultParsers() {
 
 export const TEST_FILENAME = testFilePath()
 
-export function eslintVersionSatisfies(specifier: string) {
-  return semver.satisfies(eslintPkg.version, specifier)
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simplify testing
 export type ValidTestCase = TSESLintValidTestCase<any> & {
   errors?: readonly InvalidTestCaseError[] | number
@@ -57,18 +52,8 @@ export type ValidTestCase = TSESLintValidTestCase<any> & {
   parserOptions?: never
 }
 
-export type InvalidTestCase = // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simplify testing
+type InvalidTestCase = // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simplify testing
   TSESLintInvalidTestCase<any, any>
-
-export function testVersion<T extends ValidTestCase>(
-  specifier: string,
-  t: () => T,
-): T extends { errors: readonly InvalidTestCaseError[] }
-  ? InvalidTestCase[]
-  : ValidTestCase[] {
-  // @ts-expect-error -- simplify testing
-  return eslintVersionSatisfies(specifier) ? [test(t())] : []
-}
 
 /** @warning DO NOT EXPORT THIS. use {@link createRuleTestCaseFunction} or {@link test} instead */
 function createRuleTestCase<TTestCase extends TSESLintValidTestCase<unknown[]>>(
@@ -95,6 +80,7 @@ export type InvalidTestCaseError =
       type?: `${TSESTree.AST_NODE_TYPES}`
     })
 
+/** @deprecated use {@link createRuleTestCaseFunction} */
 // eslint-disable-next-line eslint-plugin/require-meta-docs-description, eslint-plugin/require-meta-type, eslint-plugin/prefer-message-ids, eslint-plugin/prefer-object-rule, eslint-plugin/require-meta-schema
 export function test<T extends ValidTestCase>(
   t: T,
@@ -105,7 +91,7 @@ export function test<T extends ValidTestCase>(
   return createRuleTestCase(t)
 }
 
-type GetRuleType<TRule> =
+type GetRuleModuleTypes<TRule> =
   TRule extends RuleModule<infer MessageIds, infer Options>
     ? {
         messageIds: MessageIds
@@ -113,9 +99,34 @@ type GetRuleType<TRule> =
       }
     : never
 
+/**
+ * Create a function that can be used to create both valid and invalid test case
+ * to be provided to {@link TSESLintRuleTester}.
+ * This function accepts one type parameter that should extend a {@link RuleModule}
+ * to be able to provide a function with typed `MessageIds` and `Options` properties
+ *
+ * @example
+ * ```ts
+ * import { createRuleTestCaseFunction } from '../utils'
+ *
+ * const test = createRuleTestCaseFunction<typeof rule>()
+ *
+ * const ruleTester = new TSESLintRuleTester()
+ *
+ * ruleTester.run(`no-useless-path-segments (${resolver})`, rule, {
+ *  valid: [
+ *    test({
+ *      code: '...',
+ *    }),
+ *  ]
+ * })
+ * ```
+ *
+ * If the `TRule` parameter is omitted default types are used.
+ */
 export function createRuleTestCaseFunction<
   TRule extends RuleModule<string, unknown[]>,
-  TData extends GetRuleType<TRule> = GetRuleType<TRule>,
+  TData extends GetRuleModuleTypes<TRule> = GetRuleModuleTypes<TRule>,
   TTestCase extends
     | TSESLintValidTestCase<TData['options']>
     | TSESLintInvalidTestCase<TData['messageIds'], TData['options']> =
@@ -206,6 +217,6 @@ export const SYNTAX_CASES = [
   }),
 ]
 
-export const testCompiled = process.env.TEST_COMPILED === '1'
+const testCompiled = process.env.TEST_COMPILED === '1'
 
 export const srcDir = testCompiled ? 'lib' : 'src'


### PR DESCRIPTION
During #174 and #175 I noticed that in test files rule `options` types are not inferred inside `test` functions.

To avoid this problem I added `createRuleTestCaseFunction` that returns a function that can be used to generate both valid and invalid cases.

This function accept only 1 type parameter which is used to infer rule `Options` and `MessageIds` which are not exported from the rule source file.

### Pros

The immediate advantage is that now types are properly inferred from the rule declaration and a type error is reported if the rule `Options` type doesn't match them:

<details>
<summary>Intellisense on rule options screenshot</summary>

<img width="631" alt="options-intellisense" src="https://github.com/user-attachments/assets/4e9658a9-64a8-42c3-bd2a-15868592152e">

</details>

---

Additionally also rule `MessageIds` type can be inferred and provided as autocomplete suggestions:

<details>
<summary>Intellisense on rule message ids screenshot</summary>

<img width="605" alt="message-intellisense" src="https://github.com/user-attachments/assets/64eb48cf-bc72-43af-af93-bc04d67dcc9f">

</details>

### Cons

The only problem is that Invalid test case `errors` property now use the `messageId` and `data` structure rather than simple strings: you can see the impact of these changes on the two rules test files changed in this PR.

I'm willing to convert all test to this pattern but I understand that this will also increase maintenance efforts while pulling changes from the upstream repository, so no problem if you don't want to proceed with this change 😉.

