### PR TITLE
feat: implement custom resolver interface v3

### DIFF
--- a/.changeset/orange-nails-attack.md
+++ b/.changeset/orange-nails-attack.md
@@ -1,0 +1,184 @@
+The PR implements the new resolver design proposed in https://github.com/un-ts/eslint-plugin-import-x/issues/40#issuecomment-2381444266
+
+----
+
+### For `eslint-plugin-import-x` users
+
+Like the ESLint flat config allows you to use any js objects (e.g. import and require) as ESLint plugins, the new `eslint-plugin-import-x` resolver settings allow you to use any js objects as custom resolvers through the new setting `import-x/resolver-next`:
+
+```js
+// eslint.config.js
+import { createTsResolver } from '#custom-resolver';
+const { createOxcResolver } = require('path/to/a/custom/resolver');
+
+const nodeResolverObject = {
+  interfaceVersion: 3,
+  name: 'my-custom-eslint-import-resolver',
+  resolve(modPath, sourcePath) {
+  };
+};
+
+module.exports = {
+  settings: {
+    // multiple resolvers
+    'import-x/resolver-next': [
+      nodeResolverObject,
+      createTsResolver(enhancedResolverOptions),
+      createOxcResolver(oxcOptions),
+    ],
+    // single resolver:
+    'import-x/resolver-next': [createOxcResolver(oxcOptions)]
+  }
+}
+```
+
+The new `import-x/resolver-next` no longer accepts strings as the resolver, thus will not be compatible with the ESLint legacy config (a.k.a. `.eslintrc`). Those who are still using the ESLint legacy config should stick with `import-x/resolver`.
+
+In the next major version of `eslint-plugin-import-x` (v5), we will rename the currently existing `import-x/resolver` to `import-x/resolver-legacy` (which still allows the existing ESLint legacy config users to use their existing resolver settings), and `import-x/resolver-next` will become the new `import-x/resolver`. When ESLint v9 (the last ESLint version with ESLint legacy config support) reaches EOL in the future, we will remove `import-x/resolver-legacy`.
+
+We have also made a few breaking changes to the new resolver API design, so you can't use existing custom resolvers directly with `import-x/resolver-next`:
+
+```js
+// An example of the current `import-x/resolver` settings
+module.exports = {
+  settings: {
+    'import-x/resolver': {
+      node: nodeResolverOpt
+      webpack: webpackResolverOpt,
+      'custom-resolver': customResolverOpt
+    }
+  }
+}
+
+// When migrating to `import-x/resolver-next`, you CAN'T use legacy versions of resolvers directly:
+module.exports = {
+  settings: {
+    // THIS WON'T WORK, the resolver interface required for `import-x/resolver-next` is different.
+    'import-x/resolver-next': [
+       require('eslint-import-resolver-node'),
+       require('eslint-import-resolver-webpack'),
+       require('some-custom-resolver')
+    ];
+  }
+}
+```
+
+For easier migration, the PR also introduces a compat utility `importXResolverCompat` that you can use in your `eslint.config.js`:
+
+```js
+// eslint.config.js
+import eslintPluginImportX, { importXResolverCompat } from 'eslint-plugin-import-x';
+// or
+const eslintPluginImportX = require('eslint-plugin-import-x');
+const { importXResolverCompat } = eslintPluginImportX;
+
+module.exports = {
+  settings: {
+    // THIS WILL WORK as you have wrapped the previous version of resolvers with the `importXResolverCompat`
+    'import-x/resolver-next': [
+       importXResolverCompat(require('eslint-import-resolver-node'), nodeResolveOptions),
+       importXResolverCompat(require('eslint-import-resolver-webpack'), webpackResolveOptions),
+       importXResolverCompat(require('some-custom-resolver'), {})
+    ];
+  }
+}
+```
+
+### For custom import resolver developers
+
+This is the new API design of the resolver interface:
+
+```ts
+export interface NewResolver {
+  interfaceVersion: 3,
+  name?: string, // This will be included in the debug log
+  resolve: (modulePath: string, sourceFile: string) => ResolvedResult
+}
+
+// The `ResultNotFound` (returned when not resolved) is the same, no changes
+export interface ResultNotFound {
+  found: false
+  path?: undefined
+}
+
+// The `ResultFound` (returned resolve result) is also the same, no changes
+export interface ResultFound {
+  found: true
+  path: string | null
+}
+
+export type ResolvedResult = ResultNotFound | ResultFound
+```
+
+You will be able to import `NewResolver` from `eslint-plugin-import-x/types`.
+
+The most notable change is that `eslint-plugin-import-x` no longer passes the third argument (`options`) to the `resolve` function.
+
+We encourage custom resolvers' authors to consume the options outside the actual `resolve` function implementation. You can export a factory function to accept the options, this factory function will then be called inside the `eslint.config.js` to get the actual resolver:
+
+```js
+// custom-resolver.js
+exports.createCustomResolver = (options) => {
+  // The options are consumed outside the `resolve` function.
+  const resolverInstance = new ResolverFactory(options);
+
+  return {
+    name: 'custom-resolver',
+    interfaceVersion: 3,
+    resolve(mod, source) {
+      const found = resolverInstance.resolve(mod, {});
+
+      // Of course, you still have access to the `options` variable here inside
+      // the `resolve` function. That's the power of JavaScript Closures~
+    }
+  }
+};
+
+// eslint.config.js
+const { createCustomResolver } = require('custom-resolver')
+
+module.exports = {
+  settings: {
+    'import-x/resolver-next': [
+       createCustomResolver(options)
+    ];
+  }
+}
+```
+
+This allows you to create a reusable resolver instance to improve the performance. With the existing version of the resolver interface, because the options are passed to the `resolver` function, you will have to create a resolver instance every time the `resolve` function is called:
+
+```js
+module.exports = {
+  interfaceVersion: 2,
+  resolve(mod, source) {
+    // every time the `resolve` function is called, a new instance is created
+    // This is very slow
+    const resolverInstance = ResolverFactory.createResolver({});
+    const found = resolverInstance.resolve(mod, {});
+  }
+}
+```
+
+With the factory function pattern, you can create a resolver instance beforehand:
+
+```js
+exports.createCustomResolver = (options) => {
+  // `enhance-resolve` allows you to create a reusable instance:
+  const resolverInstance = ResolverFactory.createResolver({});
+  const resolverInstance = enhanceResolve.create({});
+
+  // `oxc-resolver` also allows you to create a reusable instance:
+  const resolverInstance = new ResolverFactory({});
+
+  return {
+    name: 'custom-resolver',
+    interfaceVersion: 3,
+    resolve(mod, source) {
+      // the same re-usable instance is shared across `resolve` invocations.
+      // more performant
+      const found = resolverInstance.resolve(mod, {});
+    }
+  }
+};
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,5 +182,5 @@ export = {
   configs,
   flatConfigs,
   rules,
-  importXResolverCompat
+  importXResolverCompat,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ import type {
   PluginFlatBaseConfig,
   PluginFlatConfig,
 } from './types'
+import { importXResolverCompat } from './utils'
 
 const rules = {
   'no-unresolved': noUnresolved,
@@ -181,4 +182,5 @@ export = {
   configs,
   flatConfigs,
   rules,
+  importXResolverCompat
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import type { ImportType as ImportType_, PluginName } from './utils'
 import type { LegacyImportResolver, LegacyResolver } from './utils/legacy-resolver-settings'
 
 export type {
+  LegacyResolver,
+
   LegacyResolverName,
   LegacyResolverName as ResolverName,
 
@@ -47,6 +49,20 @@ export type TsResolverOptions = {
   extensions?: string[]
 } & Omit<ResolveOptions, 'fileSystem' | 'useSyncFileSystemCalls'>
 
+// TODO: remove prefix New in the next major version
+export type NewResolverResolve = (
+  modulePath: string,
+  sourceFile: string,
+) => ResolvedResult
+
+// TODO: remove prefix New in the next major version
+export type NewResolver = {
+  interfaceVersion: 3,
+  /** optional name for the resolver, this is used in logs/debug output */
+  name?: string,
+  resolve: NewResolverResolve,
+}
+
 export type FileExtension = `.${string}`
 
 export type DocStyle = 'jsdoc' | 'tomdoc'
@@ -63,7 +79,7 @@ export type ResultFound = {
   path: string | null
 }
 
-export type Resolver = LegacyResolver
+export type Resolver = LegacyResolver | NewResolver
 
 export type ResolvedResult = ResultNotFound | ResultFound
 
@@ -80,6 +96,7 @@ export type ImportSettings = {
   parsers?: Record<string, readonly FileExtension[]>
   resolve?: NodeResolverOptions
   resolver?: LegacyImportResolver
+  'resolver-next'?: NewResolver[]
 }
 
 export type WithPluginName<T extends string | object> = T extends string

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,26 +4,29 @@ import type { MinimatchOptions } from 'minimatch'
 import type { KebabCase } from 'type-fest'
 
 import type { ImportType as ImportType_, PluginName } from './utils'
-import type { LegacyImportResolver, LegacyResolver } from './utils/legacy-resolver-settings'
+import type {
+  LegacyImportResolver,
+  LegacyResolver,
+} from './utils/legacy-resolver-settings'
 
 export type {
   LegacyResolver,
-
+  // ResolverName
   LegacyResolverName,
   LegacyResolverName as ResolverName,
-
+  // ImportResolver
   LegacyImportResolver,
   LegacyImportResolver as ImportResolver,
-
+  // ResolverResolve
   LegacyResolverResolve,
   LegacyResolverResolve as ResolverResolve,
-
+  // ResolverResolveImport
   LegacyResolverResolveImport,
   LegacyResolverResolveImport as ResolverResolveImport,
-
+  // ResolverRecord
   LegacyResolverRecord,
   LegacyResolverRecord as ResolverRecord,
-
+  // ResolverObject
   LegacyResolverObject,
   LegacyResolverObject as ResolverObject,
 } from './utils/legacy-resolver-settings'
@@ -57,10 +60,10 @@ export type NewResolverResolve = (
 
 // TODO: remove prefix New in the next major version
 export type NewResolver = {
-  interfaceVersion: 3,
+  interfaceVersion: 3
   /** optional name for the resolver, this is used in logs/debug output */
-  name?: string,
-  resolve: NewResolverResolve,
+  name?: string
+  resolve: NewResolverResolve
 }
 
 export type FileExtension = `.${string}`
@@ -96,6 +99,7 @@ export type ImportSettings = {
   parsers?: Record<string, readonly FileExtension[]>
   resolve?: NodeResolverOptions
   resolver?: LegacyImportResolver
+  'resolver-legacy'?: LegacyImportResolver
   'resolver-next'?: NewResolver[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,30 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import type { ResolveOptions } from 'enhanced-resolve'
 import type { MinimatchOptions } from 'minimatch'
-import type { KebabCase, LiteralUnion } from 'type-fest'
+import type { KebabCase } from 'type-fest'
 
 import type { ImportType as ImportType_, PluginName } from './utils'
+import type { LegacyImportResolver, LegacyResolver } from './utils/legacy-resolver-settings'
+
+export type {
+  LegacyResolverName,
+  LegacyResolverName as ResolverName,
+
+  LegacyImportResolver,
+  LegacyImportResolver as ImportResolver,
+
+  LegacyResolverResolve,
+  LegacyResolverResolve as ResolverResolve,
+
+  LegacyResolverResolveImport,
+  LegacyResolverResolveImport as ResolverResolveImport,
+
+  LegacyResolverRecord,
+  LegacyResolverRecord as ResolverRecord,
+
+  LegacyResolverObject,
+  LegacyResolverObject as ResolverObject,
+} from './utils/legacy-resolver-settings'
 
 export type ImportType = ImportType_ | 'object' | 'type'
 
@@ -42,63 +63,9 @@ export type ResultFound = {
   path: string | null
 }
 
+export type Resolver = LegacyResolver
+
 export type ResolvedResult = ResultNotFound | ResultFound
-
-export type ResolverResolve<T = unknown> = (
-  modulePath: string,
-  sourceFile: string,
-  config: T,
-) => ResolvedResult
-
-export type ResolverResolveImport<T = unknown> = (
-  modulePath: string,
-  sourceFile: string,
-  config: T,
-) => string | undefined
-
-export type Resolver<T = unknown, U = T> = {
-  interfaceVersion?: 1 | 2
-  resolve: ResolverResolve<T>
-  resolveImport: ResolverResolveImport<U>
-}
-
-export type ResolverName = LiteralUnion<
-  'node' | 'typescript' | 'webpack',
-  string
->
-
-export type ResolverRecord = {
-  node?: boolean | NodeResolverOptions
-  typescript?: boolean | TsResolverOptions
-  webpack?: WebpackResolverOptions
-  [resolve: string]: unknown
-}
-
-export type ResolverObject = {
-  // node, typescript, webpack...
-  name: ResolverName
-
-  // Enabled by default
-  enable?: boolean
-
-  // Options passed to the resolver
-  options?:
-    | NodeResolverOptions
-    | TsResolverOptions
-    | WebpackResolverOptions
-    | unknown
-
-  // Any object satisfied Resolver type
-  resolver: Resolver
-}
-
-export type ImportResolver =
-  | ResolverName
-  | ResolverRecord
-  | ResolverObject
-  | ResolverName[]
-  | ResolverRecord[]
-  | ResolverObject[]
 
 export type ImportSettings = {
   cache?: {
@@ -112,7 +79,7 @@ export type ImportSettings = {
   internalRegex?: string
   parsers?: Record<string, readonly FileExtension[]>
   resolve?: NodeResolverOptions
-  resolver?: ImportResolver
+  resolver?: LegacyImportResolver
 }
 
 export type WithPluginName<T extends string | object> = T extends string

--- a/src/utils/legacy-resolver-settings.ts
+++ b/src/utils/legacy-resolver-settings.ts
@@ -1,0 +1,185 @@
+// Although the new import resolver settings is still `import-x/resolver-next`, but it won't stop us from calling existing ones legacy~
+
+import type { LiteralUnion } from "type-fest"
+
+import { createRequire } from 'node:module'
+import type { NodeResolverOptions, ResolvedResult, TsResolverOptions, WebpackResolverOptions } from "../types"
+import path from "path"
+import { IMPORT_RESOLVE_ERROR_NAME } from "./resolve"
+import { pkgDir } from './pkg-dir'
+
+export type LegacyResolverName = LiteralUnion<
+  'node' | 'typescript' | 'webpack',
+  string
+>
+
+export type LegacyResolverResolveImport<T = unknown> = (
+  modulePath: string,
+  sourceFile: string,
+  config: T,
+) => string | undefined
+
+export type LegacyResolverResolve<T = unknown> = (
+  modulePath: string,
+  sourceFile: string,
+  config: T,
+) => ResolvedResult
+
+export type LegacyResolver<T = unknown, U = T> = {
+  interfaceVersion?: 1 | 2
+  resolve: LegacyResolverResolve<T>
+  resolveImport: LegacyResolverResolveImport<U>
+}
+
+export type LegacyResolverObject = {
+  // node, typescript, webpack...
+  name: LegacyResolverName
+
+  // Enabled by default
+  enable?: boolean
+
+  // Options passed to the resolver
+  options?:
+  | NodeResolverOptions
+  | TsResolverOptions
+  | WebpackResolverOptions
+  | unknown
+
+  // Any object satisfied Resolver type
+  resolver: LegacyResolver
+}
+
+export type LegacyResolverRecord = {
+  node?: boolean | NodeResolverOptions
+  typescript?: boolean | TsResolverOptions
+  webpack?: WebpackResolverOptions
+  [resolve: string]: unknown
+}
+
+export type LegacyImportResolver =
+  | LegacyResolverName
+  | LegacyResolverRecord
+  | LegacyResolverObject
+  | LegacyResolverName[]
+  | LegacyResolverRecord[]
+  | LegacyResolverObject[];
+
+export function normalizeConfigResolvers(
+  resolvers: LegacyImportResolver,
+  sourceFile: string,
+) {
+  const resolverArray = Array.isArray(resolvers) ? resolvers : [resolvers]
+  const map = new Map<string, Required<LegacyResolverObject>>()
+
+  for (const nameOrRecordOrObject of resolverArray) {
+    if (typeof nameOrRecordOrObject === 'string') {
+      const name = nameOrRecordOrObject
+
+      map.set(name, {
+        name,
+        enable: true,
+        options: undefined,
+        resolver: requireResolver(name, sourceFile),
+      })
+    } else if (typeof nameOrRecordOrObject === 'object') {
+      if (nameOrRecordOrObject.name && nameOrRecordOrObject.resolver) {
+        const object = nameOrRecordOrObject as LegacyResolverObject
+
+        const { name, enable = true, options, resolver } = object
+        map.set(name, { name, enable, options, resolver })
+      } else {
+        const record = nameOrRecordOrObject as LegacyResolverRecord
+
+        for (const [name, enableOrOptions] of Object.entries(record)) {
+          if (typeof enableOrOptions === 'boolean') {
+            map.set(name, {
+              name,
+              enable: enableOrOptions,
+              options: undefined,
+              resolver: requireResolver(name, sourceFile),
+            })
+          } else {
+            map.set(name, {
+              name,
+              enable: true,
+              options: enableOrOptions,
+              resolver: requireResolver(name, sourceFile),
+            })
+          }
+        }
+      }
+    } else {
+      const err = new Error('invalid resolver config')
+      err.name = IMPORT_RESOLVE_ERROR_NAME
+      throw err
+    }
+  }
+
+  return [...map.values()]
+}
+
+function requireResolver(name: string, sourceFile: string) {
+  // Try to resolve package with conventional name
+  const resolver =
+    tryRequire(`eslint-import-resolver-${name}`, sourceFile) ||
+    tryRequire(name, sourceFile) ||
+    tryRequire(path.resolve(getBaseDir(sourceFile), name))
+
+  if (!resolver) {
+    const err = new Error(`unable to load resolver "${name}".`)
+    err.name = IMPORT_RESOLVE_ERROR_NAME
+    throw err
+  }
+  if (!isLegacyResolverValid(resolver)) {
+    const err = new Error(`${name} with invalid interface loaded as resolver`)
+    err.name = IMPORT_RESOLVE_ERROR_NAME
+    throw err
+  }
+
+  return resolver
+}
+
+function isLegacyResolverValid(resolver: object): resolver is LegacyResolver {
+  if ('interfaceVersion' in resolver && resolver.interfaceVersion === 2) {
+    return (
+      'resolve' in resolver &&
+      !!resolver.resolve &&
+      typeof resolver.resolve === 'function'
+    )
+  }
+  return (
+    'resolveImport' in resolver &&
+    !!resolver.resolveImport &&
+    typeof resolver.resolveImport === 'function'
+  )
+}
+
+function tryRequire<T>(
+  target: string,
+  sourceFile?: string | null,
+): undefined | T {
+  let resolved
+  try {
+    // Check if the target exists
+    if (sourceFile == null) {
+      resolved = require.resolve(target)
+    } else {
+      try {
+        resolved = createRequire(path.resolve(sourceFile)).resolve(target)
+      } catch {
+        resolved = require.resolve(target)
+      }
+    }
+  } catch {
+    // If the target does not exist then just return undefined
+    return undefined
+  }
+
+  // If the target exists then return the loaded module
+  return require(resolved)
+}
+
+
+function getBaseDir(sourceFile: string): string {
+  return pkgDir(sourceFile) || process.cwd()
+}

--- a/src/utils/legacy-resolver-settings.ts
+++ b/src/utils/legacy-resolver-settings.ts
@@ -1,12 +1,19 @@
 // Although the new import resolver settings is still `import-x/resolver-next`, but it won't stop us from calling existing ones legacy~
 
-import type { LiteralUnion } from "type-fest"
-
 import { createRequire } from 'node:module'
-import type { NodeResolverOptions, ResolvedResult, TsResolverOptions, WebpackResolverOptions } from "../types"
-import path from "path"
-import { IMPORT_RESOLVE_ERROR_NAME } from "./resolve"
+import path from 'node:path'
+
+import type { LiteralUnion } from 'type-fest'
+
+import type {
+  NodeResolverOptions,
+  ResolvedResult,
+  TsResolverOptions,
+  WebpackResolverOptions,
+} from '../types'
+
 import { pkgDir } from './pkg-dir'
+import { IMPORT_RESOLVE_ERROR_NAME } from './resolve'
 
 export type LegacyResolverName = LiteralUnion<
   'node' | 'typescript' | 'webpack',
@@ -40,10 +47,10 @@ export type LegacyResolverObject = {
 
   // Options passed to the resolver
   options?:
-  | NodeResolverOptions
-  | TsResolverOptions
-  | WebpackResolverOptions
-  | unknown
+    | NodeResolverOptions
+    | TsResolverOptions
+    | WebpackResolverOptions
+    | unknown
 
   // Any object satisfied Resolver type
   resolver: LegacyResolver
@@ -62,9 +69,14 @@ export type LegacyImportResolver =
   | LegacyResolverObject
   | LegacyResolverName[]
   | LegacyResolverRecord[]
-  | LegacyResolverObject[];
+  | LegacyResolverObject[]
 
-export function resolveWithLegacyResolver(resolver: LegacyResolver, config: unknown, modulePath: string, sourceFile: string): ResolvedResult {
+export function resolveWithLegacyResolver(
+  resolver: LegacyResolver,
+  config: unknown,
+  modulePath: string,
+  sourceFile: string,
+): ResolvedResult {
   if (resolver.interfaceVersion === 2) {
     return resolver.resolve(modulePath, sourceFile, config)
   }
@@ -201,7 +213,6 @@ function tryRequire<T>(
   // If the target exists then return the loaded module
   return require(resolved)
 }
-
 
 function getBaseDir(sourceFile: string): string {
   return pkgDir(sourceFile) || process.cwd()

--- a/src/utils/legacy-resolver-settings.ts
+++ b/src/utils/legacy-resolver-settings.ts
@@ -64,6 +64,29 @@ export type LegacyImportResolver =
   | LegacyResolverRecord[]
   | LegacyResolverObject[];
 
+export function resolveWithLegacyResolver(resolver: LegacyResolver, config: unknown, modulePath: string, sourceFile: string): ResolvedResult {
+  if (resolver.interfaceVersion === 2) {
+    return resolver.resolve(modulePath, sourceFile, config)
+  }
+
+  try {
+    const resolved = resolver.resolveImport(modulePath, sourceFile, config)
+    if (resolved === undefined) {
+      return {
+        found: false,
+      }
+    }
+    return {
+      found: true,
+      path: resolved,
+    }
+  } catch {
+    return {
+      found: false,
+    }
+  }
+}
+
 export function normalizeConfigResolvers(
   resolvers: LegacyImportResolver,
   sourceFile: string,

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -146,7 +146,9 @@ function fullResolve(
         : `settings['import-x/resolver-next'][${i}]`
 
       if (!isValidNewResolver(resolver)) {
-        const err = new TypeError(`${resolverName} is not a valid import resolver for eslint-plugin-import-x!`)
+        const err = new TypeError(
+          `${resolverName} is not a valid import resolver for eslint-plugin-import-x!`,
+        )
         err.name = IMPORT_RESOLVE_ERROR_NAME
         throw err
       }
@@ -236,7 +238,10 @@ export function resolve(p: string, context: RuleContext) {
   }
 }
 
-export function importXResolverCompat(resolver: LegacyResolver | NewResolver, resolverOptions: unknown = {}): NewResolver {
+export function importXResolverCompat(
+  resolver: LegacyResolver | NewResolver,
+  resolverOptions: unknown = {},
+): NewResolver {
   // Somehow the resolver is already using v3 interface
   if (isValidNewResolver(resolver)) {
     return resolver

--- a/test/fixtures/foo-bar-resolver-v3.js
+++ b/test/fixtures/foo-bar-resolver-v3.js
@@ -1,0 +1,16 @@
+var path = require('path')
+
+exports.foobarResolver = (/** @type {import('eslint-plugin-import-x/types').NewResolver} */ {
+  name: 'resolver-foo-bar',
+  interfaceVersion: 3,
+  resolve: function (modulePath, sourceFile) {
+    var sourceFileName = path.basename(sourceFile)
+    if (sourceFileName === 'foo.js') {
+      return { found: true, path: path.join(__dirname, 'bar.jsx') }
+    }
+    if (sourceFileName === 'exception.js') {
+      throw new Error('foo-bar-resolver-v3 resolve test exception')
+    }
+    return { found: false }
+  }
+})

--- a/test/utils/resolve.spec.ts
+++ b/test/utils/resolve.spec.ts
@@ -3,16 +3,17 @@ import path from 'node:path'
 import { setTimeout } from 'node:timers/promises'
 
 import type { TSESLint } from '@typescript-eslint/utils'
-import eslintPkg from 'eslint/package.json'
-import semver from 'semver'
 
 import { testContext, testFilePath } from '../utils'
 
 import {
   CASE_SENSITIVE_FS,
   fileExistsWithCaseSync,
-  resolve,
+  resolve
 } from 'eslint-plugin-import-x/utils'
+
+import eslintPluginImportX from 'eslint-plugin-import-x'
+const { importXResolverCompat } = eslintPluginImportX;
 
 describe('resolve', () => {
   it('throws on bad parameters', () => {
@@ -138,6 +139,22 @@ describe('resolve', () => {
       }),
     ).toBeUndefined()
     expect(testContextReports.length).toBe(0)
+  })
+
+  it('importXResolverCompat()', () => {
+    let context = testContext({
+      'import-x/resolver-next': [
+        importXResolverCompat(require('../fixtures/foo-bar-resolver-v2')),
+      ],
+    })
+    expect(resolve('../fixtures/foo', context)).toBe(testFilePath('./bar.jsx'))
+
+    context = testContext({
+      'import-x/resolver-next': [
+        importXResolverCompat(require('../fixtures/foo-bar-resolver-v1')),
+      ],
+    })
+    expect(resolve('../fixtures/foo', context)).toBe(testFilePath('./bar.jsx'))
   })
 
   it('reports invalid import-x/resolver config', () => {

--- a/test/utils/resolve.spec.ts
+++ b/test/utils/resolve.spec.ts
@@ -6,14 +6,14 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import { testContext, testFilePath } from '../utils'
 
+import eslintPluginImportX from 'eslint-plugin-import-x'
 import {
   CASE_SENSITIVE_FS,
   fileExistsWithCaseSync,
-  resolve
+  resolve,
 } from 'eslint-plugin-import-x/utils'
 
-import eslintPluginImportX from 'eslint-plugin-import-x'
-const { importXResolverCompat } = eslintPluginImportX;
+const { importXResolverCompat } = eslintPluginImportX
 
 describe('resolve', () => {
   it('throws on bad parameters', () => {


### PR DESCRIPTION
The PR implements the new resolver design I proposed in https://github.com/un-ts/eslint-plugin-import-x/issues/40#issuecomment-2381444266

----

## For `eslint-plugin-import-x` users

Like the ESLint flat config allows you to use any js objects (e.g. import and require) as ESLint plugins, the new `eslint-plugin-import-x` resolver settings allow you to use js objects as custom resolvers through the new setting `import-x/resolver-next`:

```js
// eslint.config.js
import { createTsResolver } from '#custom-resolver';
const { createOxcResolver } = require('path/to/a/custom/resolver');

const nodeResolverObject = {
  interfaceVersion: 3,
  name: 'my-custom-eslint-import-resolver',
  resolve(modPath, sourcePath) {
  };
};

module.exports = {
  settings: {
    // multiple resolvers
    'import-x/resolver-next': [
      nodeResolverObject,
      createTsResolver(enhancedResolverOptions),
      createOxcResolver(oxcOptions),
    ],
    // single resolver:
    'import-x/resolver-next': [createOxcResolver(oxcOptions)]
  }
}
```

The new `import-x/resolver-next` no longer accepts strings as the resolver, thus will not be compatible with the ESLint legacy config (a.k.a. `.eslintrc`). Those who are still using the ESLint legacy config should stick with `import-x/resolver`.

In the next major version of `eslint-plugin-import-x` (v5), we will rename the currently existing `import-x/resolver` to `import-x/resolver-legacy` (which still allows the existing ESLint legacy config users to use their existing resolver settings), and `import-x/resolver-next` will become the new `import-x/resolver`. When ESLint v9 (the last ESLint version with ESLint legacy config support) reaches EOL in the future, we will remove `import-x/resolver-legacy`.

We have also made a few breaking changes to the new resolver API design, so you can't use existing custom resolvers directly with `import-x/resolver-next`:

```js
// An example of the current `import-x/resolver` settings
module.exports = {
  settings: {
    'import-x/resolver': {
      node: nodeResolverOpt
      webpack: webpackResolverOpt,
      'custom-resolver': customResolverOpt
    }
  }
}

// When migrating to `import-x/resolver-next`, you CAN'T use legacy versions of resolvers directly:
module.exports = {
  settings: {
    // THIS WON'T WORK, the resolver interface required for `import-x/resolver-next` is different.
    'import-x/resolver-next': [
       require('eslint-import-resolver-node'),
       require('eslint-import-resolver-webpack'),
       require('some-custom-resolver')
    ];
  }
}
```

For easier migration, the PR also introduces a compat utility `importXResolverCompat` that you can use in your `eslint.config.js`:

```js
// eslint.config.js
import eslintPluginImportX, { importXResolverCompat } from 'eslint-plugin-import-x';
// or
const eslintPluginImportX = require('eslint-plugin-import-x');
const { importXResolverCompat } = eslintPluginImportX;

module.exports = {
  settings: {
    // THIS WILL WORK as you have wrapped the previous version of resolvers with the `importXResolverCompat`
    'import-x/resolver-next': [
       importXResolverCompat(require('eslint-import-resolver-node'), nodeResolveOptions),
       importXResolverCompat(require('eslint-import-resolver-webpack'), webpackResolveOptions),
       importXResolverCompat(require('some-custom-resolver'), {})
    ];
  }
}
```

----

## For custom import resolver developers

This is the new API design of the resolver interface:

```ts
export interface NewResolver {
  interfaceVersion: 3,
  name?: string, // This will be included in the debug log
  resolve: (modulePath: string, sourceFile: string) => ResolvedResult
}

// The `ResultNotFound` (returned when not resolved) is the same, no changes
export interface ResultNotFound {
  found: false
  path?: undefined
}

// The `ResultFound` (returned resolve result) is also the same, no changes
export interface ResultFound {
  found: true
  path: string | null
}

export type ResolvedResult = ResultNotFound | ResultFound
```

You will be able to import `NewResolver` from `eslint-plugin-import-x/types`.

The most notable change is that `eslint-plugin-import-x` no longer passes the third argument (`options`) to the `resolve` function.

We encourage custom resolvers' authors to consume the options outside the actual `resolve` function implementation. You can export a factory function to accept the options, this factory function will then be called inside the `eslint.config.js` to get the actual resolver:

```js
// custom-resolver.js
exports.createCustomResolver = (options) => {
  // The options are consumed outside the `resolve` function.
  const resolverInstance = new ResolverFactory(options);

  return {
    name: 'custom-resolver',
    interfaceVersion: 3,
    resolve(mod, source) {
      const found = resolverInstance.resolve(mod, {});

      // Of course, you still have access to the `options` variable here inside
      // the `resolve` function. That's the power of JavaScript Closures~
    }
  }
};

// eslint.config.js
const { createCustomResolver } = require('custom-resolver')

module.exports = {
  settings: {
    'import-x/resolver-next': [
       createCustomResolver(options)
    ];
  }
}
```

This allows you to create a reusable resolver instance to improve the performance. With the existing version of the resolver interface, because the options are passed to the `resolver` function, you will have to create a resolver instance every time the `resolve` function is called:

```js
module.exports = {
  interfaceVersion: 2,
  resolve(mod, source) {
    // every time the `resolve` function is called, a new instance is created
    // This is very slow
    const resolverInstance = ResolverFactory.createResolver({});
    const found = resolverInstance.resolve(mod, {});
  }
}
```

With the factory function pattern, you can create a resolver instance beforehand:

```js
exports.createCustomResolver = (options) => {
  // `enhance-resolve` allows you to create a reusable instance:
  const resolverInstance = ResolverFactory.createResolver({});
  const resolverInstance = enhanceResolve.create({});

  // `oxc-resolver` also allows you to create a reusable instance:
  const resolverInstance = new ResolverFactory({});

  return {
    name: 'custom-resolver',
    interfaceVersion: 3,
    resolve(mod, source) {
      // the same re-usable instance is shared across `resolve` invocations.
      // more performant
      const found = resolverInstance.resolve(mod, {});
    }
  }
};
```

You can make your resolver implements both legacy resolver interface and new resolver interface:

```js
module.exports = {
  // interface version 2
  interfaceVersion: 2,
  resolve(mod, source) {
  },
  // interface version 3
  createCustomResolver(options) {
    // do something w/ options
    return {
      name: 'custom-resolver',
      interfaceVersion: 3,
      resolve(mod, source) {
        // the same re-usable instance is shared across `resolve` invocations.
        // more performant
        const found = resolverInstance.resolve(mod, {});
      }
    }
  } 
}
```