### PR TITLE
fix(`no-duplicates`): merge type import `as` with value import

### DIFF
--- a/.changeset/tasty-llamas-deny.md
+++ b/.changeset/tasty-llamas-deny.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix type-import and value-import merging when import-as is used

--- a/src/rules/no-duplicates.ts
+++ b/src/rules/no-duplicates.ts
@@ -152,7 +152,7 @@ function getFix(
           sourceCode.text
             .slice(openBrace.range[1], closeBrace.range[0])
             .split(',')
-            .map(x => x.split(' as ')[0].trim())
+            .map(x => x.split(' as ')[0].trim()),
         )
 
     const [specifiersText] = specifiers.reduce(

--- a/src/rules/no-duplicates.ts
+++ b/src/rules/no-duplicates.ts
@@ -152,7 +152,7 @@ function getFix(
           sourceCode.text
             .slice(openBrace.range[1], closeBrace.range[0])
             .split(',')
-            .map(x => x.trim()),
+            .map(x => x.split(' as ')[0].trim())
         )
 
     const [specifiersText] = specifiers.reduce(

--- a/test/rules/no-duplicates.spec.ts
+++ b/test/rules/no-duplicates.spec.ts
@@ -818,6 +818,25 @@ describe('TypeScript', () => {
               },
             ],
           }),
+          tInvalid({
+            code: "import type { AType as BType } from './foo'; import { CValue } from './foo'",
+            ...parserConfig,
+            options: [{ 'prefer-inline': true }],
+            output: `import { type AType as BType , CValue } from './foo'; `,
+            errors: [
+              {
+                ...createDuplicatedError('./foo'),
+                line: 1,
+                column: 37,
+              },
+              {
+                ...createDuplicatedError('./foo'),
+                line: 1,
+                column: 69,
+              },
+            ],
+          }),
+
         ]),
   ]
 

--- a/test/rules/no-duplicates.spec.ts
+++ b/test/rules/no-duplicates.spec.ts
@@ -836,7 +836,6 @@ describe('TypeScript', () => {
               },
             ],
           }),
-
         ]),
   ]
 


### PR DESCRIPTION
There was a bug when merging a type-import with a value-import, when the type import uses `import-as` syntax.

This handles the `import-as` case.