### PR TITLE
docs(consistent-type-specifier-style): correct default option

### DIFF
--- a/docs/rules/consistent-type-specifier-style.md
+++ b/docs/rules/consistent-type-specifier-style.md
@@ -37,10 +37,10 @@ This rule includes a fixer that will automatically convert your specifiers to th
 
 The rule accepts a single string option which may be one of:
 
-- `'prefer-inline'` - enforces that named type-only specifiers are only ever written with an inline marker; and never as part of a top-level, type-only import.
 - `'prefer-top-level'` - enforces that named type-only specifiers only ever written as part of a top-level, type-only import; and never with an inline marker.
+- `'prefer-inline'` - enforces that named type-only specifiers are only ever written with an inline marker; and never as part of a top-level, type-only import.
 
-By default the rule will use the `prefer-inline` option.
+By default the rule will use the `prefer-top-level` option.
 
 ## Examples
 

--- a/src/rules/consistent-type-specifier-style.ts
+++ b/src/rules/consistent-type-specifier-style.ts
@@ -61,8 +61,8 @@ export = createRule<[Options?], MessageId>({
     schema: [
       {
         type: 'string',
-        enum: ['prefer-inline', 'prefer-top-level'],
-        default: 'prefer-inline',
+        enum: ['prefer-top-level', 'prefer-inline'],
+        default: 'prefer-top-level',
       },
     ],
     messages: {


### PR DESCRIPTION
The default value in the docs are incorrect.

In the code, the default is `prefer-top-level`:
https://github.com/un-ts/eslint-plugin-import-x/blob/v4.6.1/src/rules/consistent-type-specifier-style.ts#L120