### PR TITLE
Added name in flat config for eslint config inspector

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,10 +173,10 @@ const flatConfigs = {
   'stage-0': createFlatConfig(stage0Flat, 'stage-0'),
 
   // useful stuff for folks using various environments
-  react: reactFlat,
-  'react-native': reactNativeFlat,
-  electron: electronFlat,
-  typescript: typescriptFlat,
+  react: createFlatConfig(reactFlat, 'react'),
+  'react-native': createFlatConfig(reactNativeFlat, 'react-native'),
+  electron: createFlatConfig(electronFlat, 'electron'),
+  typescript: createFlatConfig(typescriptFlat, 'typescript'),
 } satisfies Record<string, PluginFlatConfig>
 
 export = {


### PR DESCRIPTION
I am working on the eslint config inspector for my big flat config and I saw many anonymous configs where one of them is related to `import` so I added names in the flat configs