### PR TITLE
Document eslint-import-resolver-typescript `bun` option, fix ESM import

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,14 +299,17 @@ module.exports = {
 
 ```js
 // .eslintrc.mjs
-import tsResolver from 'eslint-import-resolver-typescript'
+import * as tsResolver from 'eslint-import-resolver-typescript'
 
 export default {
   settings: {
     'import-x/resolver': {
       name: 'tsResolver', // required, could be any string you like
       // enable: false, // optional, defaults to true
-      options: { someConfig: value }, // optional, options to pass to the resolver
+      // optional, options to pass to the resolver https://github.com/import-js/eslint-import-resolver-typescript#configuration
+      options: {
+        bun: true, // optional, resolve Bun modules, defaults to false
+      },
       resolver: tsResolver, // required, the resolver object
     },
   },
@@ -322,7 +325,10 @@ module.exports = {
     'import-x/resolver': {
       name: 'tsResolver', // required, could be any string you like
       // enable: false, // optional, defaults to true
-      options: { someConfig: value }, // optional, options to pass to the resolver
+      // optional, options to pass to the resolver https://github.com/import-js/eslint-import-resolver-typescript#configuration
+      options: {
+        bun: true, // optional, resolve Bun modules, defaults to false
+      },
       resolver: tsResolver, // required, the resolver object
     },
   },

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ export default {
       // enable: false, // optional, defaults to true
       // optional, options to pass to the resolver https://github.com/import-js/eslint-import-resolver-typescript#configuration
       options: {
-        bun: true, // optional, resolve Bun modules, defaults to false
+        bun: true, // optional, resolve Bun modules https://github.com/import-js/eslint-import-resolver-typescript#bun
       },
       resolver: tsResolver, // required, the resolver object
     },
@@ -327,7 +327,7 @@ module.exports = {
       // enable: false, // optional, defaults to true
       // optional, options to pass to the resolver https://github.com/import-js/eslint-import-resolver-typescript#configuration
       options: {
-        bun: true, // optional, resolve Bun modules, defaults to false
+        bun: true, // optional, resolve Bun modules https://github.com/import-js/eslint-import-resolver-typescript#bun
       },
       resolver: tsResolver, // required, the resolver object
     },


### PR DESCRIPTION
Motivation: https://github.com/un-ts/eslint-plugin-import-x/issues/92#issuecomment-2750642552

Document the `bun` boolean option from [`eslint-import-resolver-typescript@4.2.0`](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.2.0), to allow resolving Bun modules like `bun:test`

Also, fix the ESM import to use the `import * as` syntax for `eslint-import-resolver-typescript`

See also original issue:

- https://github.com/un-ts/eslint-plugin-import-x/issues/92

cc @SukkaW @JounQin 