### PR TITLE
fix: allow minimatch 9 or 10

### DIFF
--- a/.changeset/tasty-lemons-sing.md
+++ b/.changeset/tasty-lemons-sing.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: allow `minimatch` 9 or 10

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-import-resolver-node": "^0.3.9",
     "get-tsconfig": "^4.10.0",
     "is-glob": "^4.0.3",
-    "minimatch": "^10.0.1",
+    "minimatch": "^9.0.3 || ^10.0.1",
     "semver": "^7.7.1",
     "stable-hash": "^0.0.5",
     "tslib": "^2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6393,7 +6393,7 @@ __metadata:
     jest: "npm:^30.0.0-alpha.7"
     klaw-sync: "npm:^7.0.0"
     lint-staged: "npm:^15.5.0"
-    minimatch: "npm:^10.0.1"
+    minimatch: "npm:^9.0.3 || ^10.0.1"
     npm-run-all2: "npm:^7.0.2"
     path-serializer: "npm:^0.3.4"
     prettier: "npm:^3.5.3"
@@ -10038,7 +10038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.0.1, minimatch@npm:^10.0.0, minimatch@npm:^10.0.1":
+"minimatch@npm:10.0.1, minimatch@npm:^10.0.0, minimatch@npm:^9.0.3 || ^10.0.1":
   version: 10.0.1
   resolution: "minimatch@npm:10.0.1"
   dependencies:


### PR DESCRIPTION
minimatch 10 drops support for node < 20
fixes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated dependency version constraints for `minimatch` to support a broader range of library versions, enhancing overall compatibility.
	- Introduced a patch for `eslint-plugin-import-x` to ensure compatibility with `minimatch` versions 9 and 10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->