### PR TITLE
fix: incorrect `.d.cts` declaration

### DIFF
--- a/.changeset/sixty-poets-pay.md
+++ b/.changeset/sixty-poets-pay.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: incorrect `.d.cts` declaration

--- a/index.d.cts
+++ b/index.d.cts
@@ -1,3 +1,3 @@
-import eslintPluginImportX from './lib/index.js'
+declare const eslintPluginImportX: typeof import('./lib/index.js')
 
 export = eslintPluginImportX

--- a/index.d.cts
+++ b/index.d.cts
@@ -1,3 +1,5 @@
-declare const eslintPluginImportX: typeof import('./lib/index.js')
+import type eslintPluginImportX_ from './lib/index.js'
+
+declare const eslintPluginImportX: typeof eslintPluginImportX_
 
 export = eslintPluginImportX


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/issues/58195

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes incorrect type declaration in `index.d.cts` by using `import type` and declaring `eslintPluginImportX` with the correct type.
> 
>   - **Bug Fix**:
>     - Corrects type declaration in `index.d.cts` by changing `import` to `import type` for `eslintPluginImportX_`.
>     - Declares `eslintPluginImportX` as `typeof eslintPluginImportX_` to ensure correct type checking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 22ac7180dd2057532f54864153b248abb2f7a5b5. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected an issue with type declarations in the plugin to enhance stability and ensure consistent behavior during type checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->