### PR TITLE
fix: suppprt run with `node --eval`

### DIFF
--- a/.changeset/short-apes-sort.md
+++ b/.changeset/short-apes-sort.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: suppprt run with `node --eval`

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module'
 import type { CjsRequire } from '@pkgr/core'
 
 const cjsRequire: CjsRequire =
-  typeof require === 'undefined'
+  typeof require === 'undefined' || __filename === '[eval]'
     ? createRequire(import.meta.url)
     : /* istanbul ignore next */ require
 

--- a/test/rules/order.spec.ts
+++ b/test/rules/order.spec.ts
@@ -1,4 +1,4 @@
-import { cjsRequire, cjsRequire as require } from '@pkgr/core'
+import { cjsRequire as require } from '@pkgr/core'
 import { RuleTester as TSESLintRuleTester } from '@typescript-eslint/rule-tester'
 import type { TestCaseError as TSESLintTestCaseError } from '@typescript-eslint/rule-tester'
 import type { TSESLint } from '@typescript-eslint/utils'
@@ -17,7 +17,7 @@ const ruleTester = new TSESLintRuleTester()
 
 const flowRuleTester = new TSESLintRuleTester({
   languageOptions: {
-    parser: cjsRequire(parsers.BABEL),
+    parser: require(parsers.BABEL),
     parserOptions: {
       requireConfigFile: false,
       babelOptions: {


### PR DESCRIPTION
close #296
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `cjsRequire` to support `node --eval` and remove redundant alias in tests.
> 
>   - **Behavior**:
>     - Fix `cjsRequire` in `src/meta.ts` to support `node --eval` by checking if `__filename` is `'[eval]'`.
>   - **Tests**:
>     - Remove redundant alias `cjsRequire` in `test/rules/order.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 10b9f74609ea94faee8641255731c6181712a095. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->