### PR TITLE
fix: support run with worker eval

### DIFF
--- a/.changeset/spotty-months-end.md
+++ b/.changeset/spotty-months-end.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: suppprt run with worker eval

--- a/.changeset/spotty-months-end.md
+++ b/.changeset/spotty-months-end.md
@@ -2,4 +2,4 @@
 "eslint-plugin-import-x": patch
 ---
 
-fix: suppprt run with worker eval
+fix: support run with worker eval

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint": "^8.57.0 || ^9.0.0"
   },
   "dependencies": {
-    "@pkgr/core": "^0.2.3",
+    "@pkgr/core": "^0.2.4",
     "@types/doctrine": "^0.0.9",
     "@typescript-eslint/utils": "^8.30.1",
     "debug": "^4.4.0",
@@ -157,7 +157,7 @@
     "simple-git-hooks": "^2.12.1",
     "tinyexec": "^1.0.1",
     "ts-node": "^10.9.2",
-    "type-fest": "^4.39.1",
+    "type-fest": "^4.40.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.30.1",
     "yarn-berry-deduplicate": "^6.1.1",

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -2,8 +2,10 @@ import { createRequire } from 'node:module'
 
 import type { CjsRequire } from '@pkgr/core'
 
+const EVAL = new Set(['[eval]', '[worker eval]'])
+
 const cjsRequire: CjsRequire =
-  typeof require === 'undefined' || __filename === '[eval]'
+  typeof require === 'undefined' || EVAL.has(__filename)
     ? createRequire(import.meta.url)
     : /* istanbul ignore next */ require
 

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module'
 
 import type { CjsRequire } from '@pkgr/core'
 
+// workaround for #296
 const EVAL = new Set(['[eval]', '[worker eval]'])
 
 const cjsRequire: CjsRequire =

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -1,12 +1,12 @@
 import { createRequire } from 'node:module'
 
+import { EVAL_FILENAMES } from '@pkgr/core'
 import type { CjsRequire } from '@pkgr/core'
 
-// workaround for #296
-const EVAL = new Set(['[eval]', '[worker eval]'])
-
 const cjsRequire: CjsRequire =
-  typeof require === 'undefined' || EVAL.has(__filename)
+  typeof require === 'undefined' ||
+  // workaround for #296
+  EVAL_FILENAMES.has(__filename)
     ? createRequire(import.meta.url)
     : /* istanbul ignore next */ require
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,10 +3332,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.2.2, @pkgr/core@npm:^0.2.3":
-  version: 0.2.3
-  resolution: "@pkgr/core@npm:0.2.3"
-  checksum: 10c0/697c548226c9c5bc934c32bd9b142bf28f7d2b066295e3cb527eabb84a115ffa8c561c346e8dcb291710f9e0cc8054fbb761f65440d851e92f184fdb360b5c33
+"@pkgr/core@npm:^0.2.2, @pkgr/core@npm:^0.2.3, @pkgr/core@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "@pkgr/core@npm:0.2.4"
+  checksum: 10c0/2528a443bbbef5d4686614e1d73f834f19ccbc975f62b2a64974a6b97bcdf677b9c5e8948e04808ac4f0d853e2f422adfaae2a06e9e9f4f5cf8af76f1adf8dc1
   languageName: node
   linkType: hard
 
@@ -6375,7 +6375,7 @@ __metadata:
     "@commitlint/cli": "npm:^19.8.0"
     "@eslint/import-test-order-redirect-scoped": "link:./test/fixtures/order-redirect-scoped"
     "@eslint/js": "npm:^9.24.0"
-    "@pkgr/core": "npm:^0.2.3"
+    "@pkgr/core": "npm:^0.2.4"
     "@pkgr/rollup": "npm:^6.0.3"
     "@swc-node/jest": "npm:^1.8.13"
     "@swc/core": "npm:^1.11.21"
@@ -6437,7 +6437,7 @@ __metadata:
     tinyexec: "npm:^1.0.1"
     ts-node: "npm:^10.9.2"
     tslib: "npm:^2.8.1"
-    type-fest: "npm:^4.39.1"
+    type-fest: "npm:^4.40.0"
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.30.1"
     unrs-resolver: "npm:^1.5.0"
@@ -13223,10 +13223,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.0.0, type-fest@npm:^4.18.2, type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
-  version: 4.39.1
-  resolution: "type-fest@npm:4.39.1"
-  checksum: 10c0/f5bf302eb2e2f70658be1757aa578f4a09da3f65699b0b12b7ae5502ccea76e5124521a6e6b69540f442c3dc924c394202a2ab58718d0582725c7ac23c072594
+"type-fest@npm:^4.0.0, type-fest@npm:^4.18.2, type-fest@npm:^4.39.1, type-fest@npm:^4.40.0, type-fest@npm:^4.6.0":
+  version: 4.40.0
+  resolution: "type-fest@npm:4.40.0"
+  checksum: 10c0/b39d4da6f9a154e3db7e714cd05ccf56b53f4f0bbf74dd294cb6be4921b16ecca5cb00cb81b53ab621a31c8e8509c74b5101895ada47af9de368a317d24538a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #296
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes worker evaluation mode compatibility in `src/meta.ts` and updates dependencies in `package.json`.
> 
>   - **Bug Fix**:
>     - In `src/meta.ts`, updated `cjsRequire` logic to use `EVAL_FILENAMES.has(__filename)` for compatibility with worker evaluation mode.
>   - **Dependencies**:
>     - Updated `@pkgr/core` to `^0.2.4` and `type-fest` to `^4.40.0` in `package.json`.
>   - **Release**:
>     - Added changeset `spotty-months-end.md` for a patch release of `eslint-plugin-import-x`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 501d6439d4cca1b2d092e6997b3d6acc35b0849a. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility with worker evaluation mode to ensure smoother operation in more environments.
- **Chores**
	- Updated documentation to reflect the latest patch and changes.
	- Upgraded core dependencies for enhanced stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->