### PR TITLE
chore: use correct code `@example`

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -78,13 +78,11 @@ export type GetRuleModuleMessageIds<TRule> =
 export type GetRuleModuleOptions<TRule> =
   TRule extends RuleModule<infer _, infer Options> ? Options : never
 
-/* eslint-disable prettier/prettier -- See also https://github.com/hosseinmd/prettier-plugin-jsdoc/issues/241 */
 /**
  * Type helper to build {@link TSESLintRuleTester.run} test parameters from a
  * given {@link RuleModule}
  *
  * @example
- *   ```ts
  *   const COMMON_TESTS: RunTests<typeof rule> = {
  *     valid: [
  *       {
@@ -96,18 +94,16 @@ export type GetRuleModuleOptions<TRule> =
  *       {
  *         code: "import Foo from 'Foo';",
  *         options: ['prefer-top-level'],
- *         errors: []
+ *         errors: [],
  *       },
- *     ]
- *   ```
+ *     ],
+ *   }
  */
-/* eslint-enable prettier/prettier */
 export type RuleRunTests<
   TRule extends RuleModule<string, readonly unknown[]>,
   TRuleType extends GetRuleModuleTypes<TRule> = GetRuleModuleTypes<TRule>,
 > = TSESLintRunTests<TRuleType['messageIds'], TRuleType['options']>
 
-/* eslint-disable prettier/prettier */
 /**
  * Create two functions that can be used to create both valid and invalid test
  * case to be provided to {@link TSESLintRuleTester}. This function accepts one
@@ -115,7 +111,6 @@ export type RuleRunTests<
  * the result with typed `MessageIds` and `Options` properties
  *
  * @example
- *   ```ts
  *   import { createRuleTestCaseFunction } from '../utils'
  *
  *   const ruleTester = new TSESLintRuleTester()
@@ -132,16 +127,14 @@ export type RuleRunTests<
  *       tInvalid({
  *         code: '...',
  *       }),
- *     ]
+ *     ],
  *   })
- *   ```
  *
  * @param defaultOptions If you have a specific set of options that need to be
  *   passed to each test case you can supply them directly to this function.
  *
  *   If the `TRule` parameter is omitted default types are used.
  */
-/* eslint-enable prettier/prettier */
 export function createRuleTestCaseFunctions<
   TRule extends RuleModule<string, unknown[]>,
   TData extends GetRuleModuleTypes<TRule> = GetRuleModuleTypes<TRule>,


### PR DESCRIPTION
related https://github.com/hosseinmd/prettier-plugin-jsdoc/issues/241
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects code example formatting in JSDoc comments and removes unnecessary ESLint disable comments in `test/utils.ts`.
> 
>   - **Code Formatting**:
>     - Removed unnecessary `eslint-disable` comments related to `prettier/prettier` in `test/utils.ts`.
>     - Corrected code example formatting in JSDoc comments by ensuring proper indentation and syntax in `test/utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for dc2f71812e56b28a139eea9f6b807c113437416c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Cleaned up formatting comments and whitespace in code examples within documentation blocks. No changes to functionality or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->