### PR TITLE
feat(no-extraneous-dependencies): allow package to import itself

### DIFF
--- a/.changeset/cruel-cooks-notice.md
+++ b/.changeset/cruel-cooks-notice.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+Allow packages to import themselves in `import-x/no-extraneous-imports` if the `exports` field is defined in `package.json`

--- a/test/fixtures/package-named-exports/index.js
+++ b/test/fixtures/package-named-exports/index.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/test/fixtures/package-named-exports/node_modules/package-named-exports/index.js
+++ b/test/fixtures/package-named-exports/node_modules/package-named-exports/index.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/test/fixtures/package-named-exports/node_modules/package-named-exports/package.json
+++ b/test/fixtures/package-named-exports/node_modules/package-named-exports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-named-exports",
+  "description": "Standard, named package with exports",
+  "exports": "./index.js"
+}

--- a/test/fixtures/package-named-exports/package.json
+++ b/test/fixtures/package-named-exports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-named-exports",
+  "description": "Standard, named package with exports",
+  "exports": "./index.js"
+}

--- a/test/fixtures/package-named/node_modules/package-named/index.js
+++ b/test/fixtures/package-named/node_modules/package-named/index.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/test/fixtures/package-named/node_modules/package-named/package.json
+++ b/test/fixtures/package-named/node_modules/package-named/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-named",
+  "description": "Standard, named package",
+  "main": "index.js"
+}

--- a/test/rules/no-extraneous-dependencies.spec.ts
+++ b/test/rules/no-extraneous-dependencies.spec.ts
@@ -238,6 +238,11 @@ ruleTester.run('no-extraneous-dependencies', rule, {
         { packageDir: packageDirMonoRepoRoot, whitelist: ['not-a-dependency'] },
       ],
     }),
+    tValid({
+      code: 'import "package-named-exports"',
+      filename: testFilePath('package-named-exports/index.js'),
+      options: [{ packageDir: testFilePath('package-named-exports') }],
+    }),
   ],
   invalid: [
     tInvalid({
@@ -444,6 +449,14 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       options: [{ includeInternal: true }],
       errors: [
         { messageId: 'missing', data: { packageName: 'not-a-dependency' } },
+      ],
+    }),
+    tInvalid({
+      code: 'import "package-named"',
+      filename: testFilePath('package-named/index.js'),
+      options: [{ packageDir: testFilePath('package-named') }],
+      errors: [
+        { messageId: 'selfImport', data: { packageName: 'package-named' } },
       ],
     }),
   ],


### PR DESCRIPTION
Allow packages to import themselves via the `package.json` exports field.

If a package tries this, but the exports field is not defined, a new message is reported.

Closes #305