### PR TITLE
docs: fix import-x/resolver-next description in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,14 +276,14 @@ You can reference resolvers in several ways (in order of precedence):
 ```js
 // eslint.config.js
 
-import { createTypeScriptResolver } from 'eslint-import-resolver-typescript'
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript'
 import { createNodeResolver } from 'eslint-plugin-import-x'
 
 export default [
   {
     settings: {
-      'import/resolver-next': [
-        createTypeScriptResolver(/* Your override options go here */),
+      'import-x/resolver-next': [
+        createTypeScriptImportResolver(/* Your override options go here */),
         createNodeResolver(/* Your override options go here */),
       ],
     },


### PR DESCRIPTION
Fix wrong eslint-import-resolver-typescript function name: `createTypeScriptResolver` => `createTypeScriptImportResolver`
[eslint-import-resolver-typescript docs](https://github.com/import-js/eslint-import-resolver-typescript?tab=readme-ov-file#configuration)
Fix wrong plugin name in settings: `import/resolver-next` => `import-x/resolver-next`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix incorrect function and plugin names in `README.md` for ESLint configuration.
> 
>   - **Documentation**:
>     - Corrects function name from `createTypeScriptResolver` to `createTypeScriptImportResolver` in `README.md`.
>     - Updates plugin name from `import/resolver-next` to `import-x/resolver-next` in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 5af71e666a1327a77f533d316c6501cdf7a9e035. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to correct the import statement and configuration key in the TypeScript resolver example for ESLint flat config.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->