### PR TITLE
Add ESLint rule to detect mis-use of enums in type imports

### DIFF
--- a/src/rules/enum-type-specifier.ts
+++ b/src/rules/enum-type-specifier.ts
@@ -1,0 +1,53 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/index.js';
+
+function isEnum(node: TSESTree.Node): boolean {
+  return node.type === 'TSEnumDeclaration';
+}
+
+export default createRule({
+  name: 'enum-type-specifier',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Detect mis-use of enums in type imports.',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      enumTypeSpecifier: 'Enum {{name}} should not be used as a type import.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.importKind === 'type') {
+          for (const specifier of node.specifiers) {
+            if (specifier.type === 'ImportSpecifier' && isEnum(specifier.imported)) {
+              context.report({
+                node: specifier,
+                messageId: 'enumTypeSpecifier',
+                data: {
+                  name: specifier.imported.name,
+                },
+              });
+            }
+          }
+        }
+      },
+      ImportSpecifier(node) {
+        if (node.importKind === 'type' && isEnum(node.imported)) {
+          context.report({
+            node,
+            messageId: 'enumTypeSpecifier',
+            data: {
+              name: node.imported.name,
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/test/rules/enum-type-specifier.spec.ts
+++ b/test/rules/enum-type-specifier.spec.ts
@@ -1,0 +1,46 @@
+import { RuleTester as TSESLintRuleTester } from '@typescript-eslint/rule-tester';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import rule from 'eslint-plugin-import-x/rules/enum-type-specifier';
+
+const ruleTester = new TSESLintRuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('enum-type-specifier', rule, {
+  valid: [
+    {
+      code: `import { Example } from 'example-file';`,
+    },
+    {
+      code: `import type { Example } from 'example-file';`,
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+    },
+    {
+      code: `import { type Example } from 'example-file';`,
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+    },
+  ],
+  invalid: [
+    {
+      code: `import type { Example } from 'example-file';`,
+      errors: [
+        {
+          messageId: 'enumTypeSpecifier',
+          data: { name: 'Example' },
+          type: AST_NODE_TYPES.ImportSpecifier,
+        },
+      ],
+    },
+    {
+      code: `import { type Example } from 'example-file';`,
+      errors: [
+        {
+          messageId: 'enumTypeSpecifier',
+          data: { name: 'Example' },
+          type: AST_NODE_TYPES.ImportSpecifier,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Add a new ESLint rule to detect mis-use of enums in type imports.

* **New Rule Implementation**
  - Add `src/rules/enum-type-specifier.ts` to create a rule that detects and reports mis-use of enums in type imports.
  - Implement `isEnum` function to check if a type is an enum.
  - Update `create` function to call `isEnum` for each import specifier and report an error if `isEnum` returns true.

* **Test Cases**
  - Add `test/rules/enum-type-specifier.spec.ts` to include test cases for detecting mis-use of enums in type imports.
  - Ensure test cases cover both `import type` and `import { type }` scenarios.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/un-ts/eslint-plugin-import-x/pull/317?shareId=8f5202e0-c72c-4fa1-8428-542f1630579c).