### PR TITLE
fix: accept non-array resolver in `resolver-next` setting

### DIFF
--- a/.changeset/cyan-icons-fetch.md
+++ b/.changeset/cyan-icons-fetch.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: accept non-array resolver in `resolver-next` setting

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,7 @@ export interface ImportSettings {
   resolve?: NodeResolverOptions
   resolver?: LegacyImportResolver
   'resolver-legacy'?: LegacyImportResolver
-  'resolver-next'?: NewResolver[]
+  'resolver-next'?: NewResolver[] | NewResolver
 }
 
 export type WithPluginName<T extends string | object> = T extends string

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -145,7 +145,11 @@ function fullResolve(
     Object.prototype.hasOwnProperty.call(settings, 'import-x/resolver-next') &&
     settings['import-x/resolver-next']
   ) {
-    const configResolvers = settings['import-x/resolver-next']
+    let configResolvers = settings['import-x/resolver-next']
+
+    if (!Array.isArray(configResolvers)) {
+      configResolvers = [configResolvers]
+    }
 
     for (let i = 0, len = configResolvers.length; i < len; i++) {
       const resolver = configResolvers[i]

--- a/test/utils/resolve.spec.ts
+++ b/test/utils/resolve.spec.ts
@@ -162,6 +162,15 @@ describe('resolve', () => {
     expect(resolve('../fixtures/foo', context)).toBe(testFilePath('./bar.jsx'))
   })
 
+  it('non-array resolver interface v3', () => {
+    const context = testContext({
+      'import-x/resolver-next': require<{
+        foobarResolver: NewResolver
+      }>('../fixtures/foo-bar-resolver-v3').foobarResolver,
+    })
+    expect(resolve('../fixtures/foo', context)).toBe(testFilePath('./bar.jsx'))
+  })
+
   it('reports invalid import-x/resolver config', () => {
     const context = testContext({
       // @ts-expect-error - testing


### PR DESCRIPTION
Fixes #320. Accept non-array `resolver-next` and cast to array ourselves.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow `resolver-next` to accept non-array inputs by casting them to arrays in `fullResolve()`.
> 
>   - **Behavior**:
>     - `resolver-next` in `ImportSettings` now accepts `NewResolver[]` or `NewResolver` in `src/types.ts`.
>     - In `fullResolve()` in `src/utils/resolve.ts`, non-array `resolver-next` is cast to an array.
>   - **Misc**:
>     - Fixes #320 by handling non-array `resolver-next`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for ae66788f40c62186bd5dd0f75268f031396dd24b. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for the 'resolver-next' setting, allowing both single resolver objects and arrays of resolvers to be used without causing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->