### PR TITLE
fix: remove buggy `module-sync` exports field

### DIFF
--- a/.changeset/purple-penguins-beam.md
+++ b/.changeset/purple-penguins-beam.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: remove buggy `module-sync` exports field

--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
         "types": "./lib/index.d.ts",
         "default": "./lib/index.js"
       },
-      "module-sync": {
-        "types": "./lib/index.d.ts",
-        "default": "./lib/index.js"
-      },
       "require": {
         "types": "./index.d.cts",
         "default": "./lib/index.cjs"


### PR DESCRIPTION
https://github.com/nodejs/node/issues/57869
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove buggy `module-sync` export field from `package.json`.
> 
>   - **Exports**:
>     - Remove `module-sync` export field from `package.json` to fix a bug related to module resolution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 04d2481b448b707fe3d9a79c454145e2784924da. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the package configuration by removing the "module-sync" export entry. Only "import" and "require" options are now available for module exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->