### PR TITLE
fix: share same plugin reference for default export

### DIFF
--- a/.changeset/nasty-dolls-check.md
+++ b/.changeset/nasty-dolls-check.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: share same plugin reference for default export

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ In the new system, `.eslintrc*` is no longer used. `eslint.config.*` would be th
 
 ```js
 import js from '@eslint/js'
-import * as importX from 'eslint-plugin-import-x'
+import { importX } from 'eslint-plugin-import-x'
 
 export default [js.configs.recommended, importX.flatConfigs.recommended]
 ```
@@ -114,7 +114,7 @@ npm install eslint-import-resolver-typescript --save-dev
 
 ```js
 import js from '@eslint/js'
-import * as importX from 'eslint-plugin-import-x'
+import { importX } from 'eslint-plugin-import-x'
 import tsParser from '@typescript-eslint/parser'
 
 export default [

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,11 @@ const configs = {
 // Base Plugin Object
 const plugin = {
   meta,
+  configs,
   rules,
+  cjsRequire,
+  importXResolverCompat,
+  createNodeResolver,
 }
 
 // Create flat configs (Only ones that declare plugins and parser options need to be different from the legacy config)
@@ -179,15 +183,7 @@ const flatConfigs = {
   typescript: createFlatConfig(typescriptFlat, 'typescript'),
 } satisfies Record<string, PluginFlatConfig>
 
-export default {
-  meta,
-  configs,
-  flatConfigs,
-  rules,
-  cjsRequire,
-  importXResolverCompat,
-  createNodeResolver,
-}
+export default Object.assign(plugin, { flatConfigs })
 
 export {
   meta,
@@ -197,6 +193,7 @@ export {
   cjsRequire,
   importXResolverCompat,
   createNodeResolver,
+  plugin as importX,
 }
 
 export type * from './types.js'


### PR DESCRIPTION
Avoid `Cannot redefine plugin "import-x"` error
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes plugin redefinition error by ensuring a single reference for default export and updates import syntax in README.
> 
>   - **Behavior**:
>     - Fixes `Cannot redefine plugin "import-x"` error by ensuring a single plugin reference for default export in `src/index.ts`.
>     - Updates import syntax in `README.md` to use `{ importX }` instead of `* as importX`.
>   - **Refactor**:
>     - Combines `plugin` object with `flatConfigs` using `Object.assign()` in `src/index.ts`.
>   - **Chores**:
>     - Adds `.changeset/nasty-dolls-check.md` to document the patch update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 8925d8b386dc6bab2d5dab0eafe05feeecfae97d. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced plugin export structure for improved compatibility and ease of use.
- **Chores**
  - Added documentation for a patch update related to plugin export handling. No impact on functionality.
- **Documentation**
  - Updated import examples in the README for clearer usage of the plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->