### PR TITLE
fix: rule `dynamic-import-chunkname` crash due to ts migration

### DIFF
--- a/.changeset/pink-readers-design.md
+++ b/.changeset/pink-readers-design.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: rule `dynamic-import-chunkname` crash due to ts migration

--- a/src/rules/dynamic-import-chunkname.ts
+++ b/src/rules/dynamic-import-chunkname.ts
@@ -232,8 +232,8 @@ export default createRule<[Options?], MessageId>({
         if (
           // @ts-expect-error - legacy parser type
           node.callee.type !== 'Import' &&
-          'name' in node.callee &&
-          !importFunctions.includes(node.callee.name)
+          (!('name' in node.callee) ||
+            !importFunctions.includes(node.callee.name))
         ) {
           return
         }

--- a/test/rules/dynamic-import-chunkname.spec.ts
+++ b/test/rules/dynamic-import-chunkname.spec.ts
@@ -1154,6 +1154,7 @@ export default function useAbortSignal(signal: AbortSignal): boolean {
     () => signal.aborted,
   );
 }`,
+        options,
       },
     ],
     invalid: [

--- a/test/rules/dynamic-import-chunkname.spec.ts
+++ b/test/rules/dynamic-import-chunkname.spec.ts
@@ -1136,6 +1136,25 @@ describe('TypeScript', () => {
           )`,
         options,
       },
+      {
+        code: `import { useSyncExternalStore } from "use-sync-external-store/shim";
+
+export default function useAbortSignal(signal: AbortSignal): boolean {
+  return useSyncExternalStore(
+    (callback: () => void) => {
+      const unsubscribe = new AbortController();
+      signal.addEventListener("abort", callback, {
+        signal: unsubscribe.signal,
+        once: true,
+      });
+      return () => {
+        unsubscribe.abort();
+      };
+    },
+    () => signal.aborted,
+  );
+}`,
+      },
     ],
     invalid: [
       {


### PR DESCRIPTION
close #345
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix crash in `dynamic-import-chunkname` rule by improving dynamic import checks and add a new TypeScript test case.
> 
>   - **Bug Fixes**:
>     - Fix crash in `dynamic-import-chunkname` rule in `dynamic-import-chunkname.ts` by improving handling of dynamic import checks when certain properties are missing.
>   - **Tests**:
>     - Add new valid TypeScript test case in `dynamic-import-chunkname.spec.ts` for dynamic import chunk name validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for dd22dba6995897826e9287e11f26ac4830426cd6. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of dynamic import checks to better support cases where certain properties may be missing.
- **Tests**
	- Added a new valid TypeScript test case for dynamic import chunk name validation, enhancing test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->