### PR TITLE
fix(types): exported `importX` should also have `flatConfigs` as property

### DIFF
--- a/.changeset/soft-fishes-cover.md
+++ b/.changeset/soft-fishes-cover.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix(types): exported `importX` should also have `flatConfigs` as property

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ const configs = {
 } satisfies Record<string, PluginConfig>
 
 // Base Plugin Object
-const plugin = {
+const plugin_ = {
   meta,
   configs,
   rules,
@@ -156,6 +156,8 @@ const plugin = {
   importXResolverCompat,
   createNodeResolver,
 }
+
+const plugin = plugin_ as typeof plugin_ & { flatConfigs: typeof flatConfigs }
 
 // Create flat configs (Only ones that declare plugins and parser options need to be different from the legacy config)
 const createFlatConfig = (
@@ -183,7 +185,9 @@ const flatConfigs = {
   typescript: createFlatConfig(typescriptFlat, 'typescript'),
 } satisfies Record<string, PluginFlatConfig>
 
-export default Object.assign(plugin, { flatConfigs })
+plugin.flatConfigs = flatConfigs
+
+export default plugin
 
 export {
   meta,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `flatConfigs` as a property to the exported `plugin` object in `index.ts`, updating its structure and export statement.
> 
>   - **Behavior**:
>     - Adds `flatConfigs` as a property to the exported `plugin` object in `index.ts`.
>     - `flatConfigs` are created using `createFlatConfig` for various configurations like `recommended`, `errors`, `warnings`, etc.
>   - **Code Structure**:
>     - Renames `plugin` to `plugin_` and then reassigns `plugin` to include `flatConfigs`.
>     - Updates export statement to include `flatConfigs` and the modified `plugin`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 9023bc76e70192127f04d73bae029f4cde357b2d. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the way configuration options are attached and exported, making the structure clearer and more readable.

- **Chores**
  - Improved type definitions to better reflect the exported structure and enhance type accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->