### PR TITLE
fix: export flat configs in configs object

### DIFF
--- a/.changeset/smooth-horses-greet.md
+++ b/.changeset/smooth-horses-greet.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": minor
+---
+
+Expose flat configs in `configs` object to allow use of ESLint `extends`

--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -4,6 +4,17 @@ import prettierRC from './.prettierrc.js'
 
 /** @type {import('eslint-doc-generator').GenerateOptions} */
 const config = {
+  configEmoji: [
+    ['recommended', '☑️'],
+    ['flat/errors', '❗'],
+    ['flat/recommended', '☑️'],
+    ['flat/typescript', '⌨️'],
+    ['flat/warnings', '🚸'],
+  ],
+  ruleDocTitleFormat: 'prefix-name',
+  ruleDocSectionOptions: false,
+  ignoreConfig: ['stage-0', 'flat/stage-0'],
+  ruleListSplit: 'meta.docs.category',
   postprocess: content =>
     format(content, { ...prettierRC, parser: 'markdown' }),
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ It started as a fork of [`eslint-plugin-import`] using [`get-tsconfig`] to repla
   - [JS example](#js-example)
   - [Typescript example](#typescript-example)
   - [As a standalone ESLint plugin](#as-a-standalone-eslint-plugin)
+  - [Using `defineConfig`](#using-defineconfig)
 - [Configuration (legacy: `.eslintrc*`)](#configuration-legacy-eslintrc)
   - [TypeScript](#typescript)
 - [Rules](#rules)
@@ -137,7 +138,7 @@ export default [
 ]
 ```
 
-> \[!NOTE]
+> [!NOTE]
 > A complete list of available configuration can be found in [config/flat folders](src/config/flat)
 
 ### As a standalone ESLint plugin
@@ -162,13 +163,32 @@ export default [
 ]
 ```
 
+### Using `defineConfig`
+
+```js
+import { importX } from 'eslint-plugin-import-x'
+import { defineConfig } from 'eslint/config'
+
+export default defineConfig([
+  {
+    plugins: {
+      'import-x': importX,
+    },
+    extends: ['import-x/flat/recommended'],
+    rules: {
+      'import-x/no-dynamic-require': 'warn',
+    },
+  },
+])
+```
+
 ## Configuration (legacy: `.eslintrc*`)
 
-> \[!TIP]
+> [!TIP]
 > If your eslint is `>=8.23.0`, you're 100% ready to use the new config system.
 > See dedicated section above.
 
-> \[!NOTE]
+> [!NOTE]
 > All rules are off by default. However, you may configure them manually
 > in your `.eslintrc.(yml|json|js)`, or extend one of the canned configs:
 
@@ -197,7 +217,7 @@ rules:
 
 You may use the following snippet or assemble your own config using the granular settings described below it.
 
-> \[!WARNING]
+> [!WARNING]
 > Make sure you have installed [`@typescript-eslint/parser`] and [`eslint-import-resolver-typescript`] which are used in the following configuration.
 
 ```yaml
@@ -221,6 +241,10 @@ settings:
 ⚠️ Configurations set to warn in.\
 🚫 Configurations disabled in.\
 ❗ Set in the `errors` configuration.\
+❗ Set in the `flat/errors` configuration.\
+☑️ Set in the `flat/recommended` configuration.\
+⌨️ Set in the `flat/typescript` configuration.\
+🚸 Set in the `flat/warnings` configuration.\
 ☑️ Set in the `recommended` configuration.\
 ⌨️ Set in the `typescript` configuration.\
 🚸 Set in the `warnings` configuration.\
@@ -230,17 +254,17 @@ settings:
 
 ### Helpful warnings
 
-| Name                                                                   | Description                                                                           | 💼                                                           | ⚠️                                                             | 🚫  | 🔧  | 💡  | ❌  |
-| :--------------------------------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------- | :------------------------------------------------------------- | :-- | :-- | :-- | :-- |
-| [export](docs/rules/export.md)                                         | Forbid any invalid exports, i.e. re-export of the same name.                          | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |                                                                |     |     |     |     |
-| [no-deprecated](docs/rules/no-deprecated.md)                           | Forbid imported names marked with `@deprecated` documentation tag.                    |                                                              | !\[badge-flat/stage-0]\[]                                      |     |     |     |     |
-| [no-empty-named-blocks](docs/rules/no-empty-named-blocks.md)           | Forbid empty named import blocks.                                                     |                                                              |                                                                |     | 🔧  | 💡  |     |
-| [no-extraneous-dependencies](docs/rules/no-extraneous-dependencies.md) | Forbid the use of extraneous packages.                                                |                                                              |                                                                |     |     |     |     |
-| [no-mutable-exports](docs/rules/no-mutable-exports.md)                 | Forbid the use of mutable exports with `var` or `let`.                                |                                                              |                                                                |     |     |     |     |
-| [no-named-as-default](docs/rules/no-named-as-default.md)               | Forbid use of exported name as identifier of default export.                          |                                                              | ☑️ 🚸 !\[badge-flat/recommended]\[] !\[badge-flat/warnings]\[] |     |     |     |     |
-| [no-named-as-default-member](docs/rules/no-named-as-default-member.md) | Forbid use of exported name as property of default export.                            |                                                              | ☑️ 🚸 !\[badge-flat/recommended]\[] !\[badge-flat/warnings]\[] |     |     |     |     |
-| [no-rename-default](docs/rules/no-rename-default.md)                   | Forbid importing a default export by a different name.                                |                                                              | 🚸 !\[badge-flat/warnings]\[]                                  |     |     |     |     |
-| [no-unused-modules](docs/rules/no-unused-modules.md)                   | Forbid modules without exports, or exports without matching import in another module. |                                                              |                                                                |     |     |     |     |
+| Name                                                                   | Description                                                                           | 💼          | ⚠️          | 🚫  | 🔧  | 💡  | ❌  |
+| :--------------------------------------------------------------------- | :------------------------------------------------------------------------------------ | :---------- | :---------- | :-- | :-- | :-- | :-- |
+| [export](docs/rules/export.md)                                         | Forbid any invalid exports, i.e. re-export of the same name.                          | ❗ ❗ ☑️ ☑️ |             |     |     |     |     |
+| [no-deprecated](docs/rules/no-deprecated.md)                           | Forbid imported names marked with `@deprecated` documentation tag.                    |             |             |     |     |     |     |
+| [no-empty-named-blocks](docs/rules/no-empty-named-blocks.md)           | Forbid empty named import blocks.                                                     |             |             |     | 🔧  | 💡  |     |
+| [no-extraneous-dependencies](docs/rules/no-extraneous-dependencies.md) | Forbid the use of extraneous packages.                                                |             |             |     |     |     |     |
+| [no-mutable-exports](docs/rules/no-mutable-exports.md)                 | Forbid the use of mutable exports with `var` or `let`.                                |             |             |     |     |     |     |
+| [no-named-as-default](docs/rules/no-named-as-default.md)               | Forbid use of exported name as identifier of default export.                          |             | ☑️ 🚸 ☑️ 🚸 |     |     |     |     |
+| [no-named-as-default-member](docs/rules/no-named-as-default-member.md) | Forbid use of exported name as property of default export.                            |             | ☑️ 🚸 ☑️ 🚸 |     |     |     |     |
+| [no-rename-default](docs/rules/no-rename-default.md)                   | Forbid importing a default export by a different name.                                |             | 🚸 🚸       |     |     |     |     |
+| [no-unused-modules](docs/rules/no-unused-modules.md)                   | Forbid modules without exports, or exports without matching import in another module. |             |             |     |     |     |     |
 
 ### Module systems
 
@@ -254,45 +278,45 @@ settings:
 
 ### Static analysis
 
-| Name                                                                   | Description                                                                          | 💼                                                           | ⚠️  | 🚫                              | 🔧  | 💡  | ❌  |
-| :--------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :----------------------------------------------------------- | :-- | :------------------------------ | :-- | :-- | :-- |
-| [default](docs/rules/default.md)                                       | Ensure a default export is present, given a default import.                          | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |     |                                 |     |     |     |
-| [named](docs/rules/named.md)                                           | Ensure named imports correspond to a named export in the remote file.                | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |     | ⌨️ !\[badge-flat/typescript]\[] |     |     |     |
-| [namespace](docs/rules/namespace.md)                                   | Ensure imported namespaces contain dereferenced properties as they are dereferenced. | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |     |                                 |     |     |     |
-| [no-absolute-path](docs/rules/no-absolute-path.md)                     | Forbid import of modules using absolute paths.                                       |                                                              |     |                                 | 🔧  |     |     |
-| [no-cycle](docs/rules/no-cycle.md)                                     | Forbid a module from importing a module with a dependency path back to itself.       |                                                              |     |                                 |     |     |     |
-| [no-dynamic-require](docs/rules/no-dynamic-require.md)                 | Forbid `require()` calls with expressions.                                           |                                                              |     |                                 |     |     |     |
-| [no-internal-modules](docs/rules/no-internal-modules.md)               | Forbid importing the submodules of other modules.                                    |                                                              |     |                                 |     |     |     |
-| [no-relative-packages](docs/rules/no-relative-packages.md)             | Forbid importing packages through relative paths.                                    |                                                              |     |                                 | 🔧  |     |     |
-| [no-relative-parent-imports](docs/rules/no-relative-parent-imports.md) | Forbid importing modules from parent directories.                                    |                                                              |     |                                 |     |     |     |
-| [no-restricted-paths](docs/rules/no-restricted-paths.md)               | Enforce which files can be imported in a given folder.                               |                                                              |     |                                 |     |     |     |
-| [no-self-import](docs/rules/no-self-import.md)                         | Forbid a module from importing itself.                                               |                                                              |     |                                 |     |     |     |
-| [no-unresolved](docs/rules/no-unresolved.md)                           | Ensure imports point to a file/module that can be resolved.                          | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |     |                                 |     |     |     |
-| [no-useless-path-segments](docs/rules/no-useless-path-segments.md)     | Forbid unnecessary path segments in import and require statements.                   |                                                              |     |                                 | 🔧  |     |     |
-| [no-webpack-loader-syntax](docs/rules/no-webpack-loader-syntax.md)     | Forbid webpack loader syntax in imports.                                             |                                                              |     |                                 |     |     |     |
+| Name                                                                   | Description                                                                          | 💼          | ⚠️  | 🚫    | 🔧  | 💡  | ❌  |
+| :--------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :---------- | :-- | :---- | :-- | :-- | :-- |
+| [default](docs/rules/default.md)                                       | Ensure a default export is present, given a default import.                          | ❗ ❗ ☑️ ☑️ |     |       |     |     |     |
+| [named](docs/rules/named.md)                                           | Ensure named imports correspond to a named export in the remote file.                | ❗ ❗ ☑️ ☑️ |     | ⌨️ ⌨️ |     |     |     |
+| [namespace](docs/rules/namespace.md)                                   | Ensure imported namespaces contain dereferenced properties as they are dereferenced. | ❗ ❗ ☑️ ☑️ |     |       |     |     |     |
+| [no-absolute-path](docs/rules/no-absolute-path.md)                     | Forbid import of modules using absolute paths.                                       |             |     |       | 🔧  |     |     |
+| [no-cycle](docs/rules/no-cycle.md)                                     | Forbid a module from importing a module with a dependency path back to itself.       |             |     |       |     |     |     |
+| [no-dynamic-require](docs/rules/no-dynamic-require.md)                 | Forbid `require()` calls with expressions.                                           |             |     |       |     |     |     |
+| [no-internal-modules](docs/rules/no-internal-modules.md)               | Forbid importing the submodules of other modules.                                    |             |     |       |     |     |     |
+| [no-relative-packages](docs/rules/no-relative-packages.md)             | Forbid importing packages through relative paths.                                    |             |     |       | 🔧  |     |     |
+| [no-relative-parent-imports](docs/rules/no-relative-parent-imports.md) | Forbid importing modules from parent directories.                                    |             |     |       |     |     |     |
+| [no-restricted-paths](docs/rules/no-restricted-paths.md)               | Enforce which files can be imported in a given folder.                               |             |     |       |     |     |     |
+| [no-self-import](docs/rules/no-self-import.md)                         | Forbid a module from importing itself.                                               |             |     |       |     |     |     |
+| [no-unresolved](docs/rules/no-unresolved.md)                           | Ensure imports point to a file/module that can be resolved.                          | ❗ ❗ ☑️ ☑️ |     |       |     |     |     |
+| [no-useless-path-segments](docs/rules/no-useless-path-segments.md)     | Forbid unnecessary path segments in import and require statements.                   |             |     |       | 🔧  |     |     |
+| [no-webpack-loader-syntax](docs/rules/no-webpack-loader-syntax.md)     | Forbid webpack loader syntax in imports.                                             |             |     |       |     |     |     |
 
 ### Style guide
 
-| Name                                                                             | Description                                                                 | 💼  | ⚠️                                                             | 🚫  | 🔧  | 💡  | ❌  |
-| :------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :-- | :------------------------------------------------------------- | :-- | :-- | :-- | :-- |
-| [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports.       |     |                                                                |     | 🔧  |     |     |
-| [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.    |     |                                                                |     |     | 💡  |     |
-| [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                           |     |                                                                |     |     |     |     |
-| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.             |     |                                                                |     | 🔧  | 💡  |     |
-| [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                          |     |                                                                |     | 🔧  |     |     |
-| [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration. |     |                                                                |     |     |     |     |
-| [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import-x/first`.                                               |     |                                                                |     | 🔧  |     | ❌  |
-| [max-dependencies](docs/rules/max-dependencies.md)                               | Enforce the maximum number of dependencies a module can have.               |     |                                                                |     |     |     |     |
-| [newline-after-import](docs/rules/newline-after-import.md)                       | Enforce a newline after import statements.                                  |     |                                                                |     | 🔧  |     |     |
-| [no-anonymous-default-export](docs/rules/no-anonymous-default-export.md)         | Forbid anonymous values as default exports.                                 |     |                                                                |     |     |     |     |
-| [no-default-export](docs/rules/no-default-export.md)                             | Forbid default exports.                                                     |     |                                                                |     |     |     |     |
-| [no-duplicates](docs/rules/no-duplicates.md)                                     | Forbid repeated import of the same module in multiple places.               |     | ☑️ 🚸 !\[badge-flat/recommended]\[] !\[badge-flat/warnings]\[] |     | 🔧  |     |     |
-| [no-named-default](docs/rules/no-named-default.md)                               | Forbid named default exports.                                               |     |                                                                |     |     |     |     |
-| [no-named-export](docs/rules/no-named-export.md)                                 | Forbid named exports.                                                       |     |                                                                |     |     |     |     |
-| [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                           |     |                                                                |     | 🔧  |     |     |
-| [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports.                                                  |     |                                                                |     |     |     |     |
-| [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                                |     |                                                                |     | 🔧  |     |     |
-| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names.  |     |                                                                |     |     |     |     |
+| Name                                                                             | Description                                                                 | 💼  | ⚠️          | 🚫  | 🔧  | 💡  | ❌  |
+| :------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :-- | :---------- | :-- | :-- | :-- | :-- |
+| [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports.       |     |             |     | 🔧  |     |     |
+| [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.    |     |             |     |     | 💡  |     |
+| [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                           |     |             |     |     |     |     |
+| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.             |     |             |     | 🔧  | 💡  |     |
+| [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                          |     |             |     | 🔧  |     |     |
+| [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration. |     |             |     |     |     |     |
+| [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import-x/first`.                                               |     |             |     | 🔧  |     | ❌  |
+| [max-dependencies](docs/rules/max-dependencies.md)                               | Enforce the maximum number of dependencies a module can have.               |     |             |     |     |     |     |
+| [newline-after-import](docs/rules/newline-after-import.md)                       | Enforce a newline after import statements.                                  |     |             |     | 🔧  |     |     |
+| [no-anonymous-default-export](docs/rules/no-anonymous-default-export.md)         | Forbid anonymous values as default exports.                                 |     |             |     |     |     |     |
+| [no-default-export](docs/rules/no-default-export.md)                             | Forbid default exports.                                                     |     |             |     |     |     |     |
+| [no-duplicates](docs/rules/no-duplicates.md)                                     | Forbid repeated import of the same module in multiple places.               |     | ☑️ 🚸 ☑️ 🚸 |     | 🔧  |     |     |
+| [no-named-default](docs/rules/no-named-default.md)                               | Forbid named default exports.                                               |     |             |     |     |     |     |
+| [no-named-export](docs/rules/no-named-export.md)                                 | Forbid named exports.                                                       |     |             |     |     |     |     |
+| [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                           |     |             |     | 🔧  |     |     |
+| [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports.                                                  |     |             |     |     |     |     |
+| [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                                |     |             |     | 🔧  |     |     |
+| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names.  |     |             |     |     |     |     |
 
 <!-- end auto-generated rules list -->
 
@@ -321,7 +345,7 @@ You can reference resolvers in several ways (in order of precedence):
 
 ### `import-x/resolver-next`
 
-> \[!warning]
+> [!warning]
 >
 > Only available in the new flat config system. If you are using the legacy config system, please use `import-x/resolver` instead.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ export default [
 ]
 ```
 
-> [!NOTE]
+> \[!NOTE]
 > A complete list of available configuration can be found in [config/flat folders](src/config/flat)
 
 ### As a standalone ESLint plugin
@@ -164,11 +164,11 @@ export default [
 
 ## Configuration (legacy: `.eslintrc*`)
 
-> [!TIP]
+> \[!TIP]
 > If your eslint is `>=8.23.0`, you're 100% ready to use the new config system.
 > See dedicated section above.
 
-> [!NOTE]
+> \[!NOTE]
 > All rules are off by default. However, you may configure them manually
 > in your `.eslintrc.(yml|json|js)`, or extend one of the canned configs:
 
@@ -197,7 +197,7 @@ rules:
 
 You may use the following snippet or assemble your own config using the granular settings described below it.
 
-> [!WARNING]
+> \[!WARNING]
 > Make sure you have installed [`@typescript-eslint/parser`] and [`eslint-import-resolver-typescript`] which are used in the following configuration.
 
 ```yaml
@@ -230,17 +230,17 @@ settings:
 
 ### Helpful warnings
 
-| Name                                                                   | Description                                                                           | 💼    | ⚠️    | 🚫  | 🔧  | 💡  | ❌  |
-| :--------------------------------------------------------------------- | :------------------------------------------------------------------------------------ | :---- | :---- | :-- | :-- | :-- | :-- |
-| [export](docs/rules/export.md)                                         | Forbid any invalid exports, i.e. re-export of the same name.                          | ❗ ☑️ |       |     |     |     |     |
-| [no-deprecated](docs/rules/no-deprecated.md)                           | Forbid imported names marked with `@deprecated` documentation tag.                    |       |       |     |     |     |     |
-| [no-empty-named-blocks](docs/rules/no-empty-named-blocks.md)           | Forbid empty named import blocks.                                                     |       |       |     | 🔧  | 💡  |     |
-| [no-extraneous-dependencies](docs/rules/no-extraneous-dependencies.md) | Forbid the use of extraneous packages.                                                |       |       |     |     |     |     |
-| [no-mutable-exports](docs/rules/no-mutable-exports.md)                 | Forbid the use of mutable exports with `var` or `let`.                                |       |       |     |     |     |     |
-| [no-named-as-default](docs/rules/no-named-as-default.md)               | Forbid use of exported name as identifier of default export.                          |       | ☑️ 🚸 |     |     |     |     |
-| [no-named-as-default-member](docs/rules/no-named-as-default-member.md) | Forbid use of exported name as property of default export.                            |       | ☑️ 🚸 |     |     |     |     |
-| [no-rename-default](docs/rules/no-rename-default.md)                   | Forbid importing a default export by a different name.                                |       | 🚸    |     |     |     |     |
-| [no-unused-modules](docs/rules/no-unused-modules.md)                   | Forbid modules without exports, or exports without matching import in another module. |       |       |     |     |     |     |
+| Name                                                                   | Description                                                                           | 💼                                                           | ⚠️                                                             | 🚫  | 🔧  | 💡  | ❌  |
+| :--------------------------------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------- | :------------------------------------------------------------- | :-- | :-- | :-- | :-- |
+| [export](docs/rules/export.md)                                         | Forbid any invalid exports, i.e. re-export of the same name.                          | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |                                                                |     |     |     |     |
+| [no-deprecated](docs/rules/no-deprecated.md)                           | Forbid imported names marked with `@deprecated` documentation tag.                    |                                                              | !\[badge-flat/stage-0]\[]                                      |     |     |     |     |
+| [no-empty-named-blocks](docs/rules/no-empty-named-blocks.md)           | Forbid empty named import blocks.                                                     |                                                              |                                                                |     | 🔧  | 💡  |     |
+| [no-extraneous-dependencies](docs/rules/no-extraneous-dependencies.md) | Forbid the use of extraneous packages.                                                |                                                              |                                                                |     |     |     |     |
+| [no-mutable-exports](docs/rules/no-mutable-exports.md)                 | Forbid the use of mutable exports with `var` or `let`.                                |                                                              |                                                                |     |     |     |     |
+| [no-named-as-default](docs/rules/no-named-as-default.md)               | Forbid use of exported name as identifier of default export.                          |                                                              | ☑️ 🚸 !\[badge-flat/recommended]\[] !\[badge-flat/warnings]\[] |     |     |     |     |
+| [no-named-as-default-member](docs/rules/no-named-as-default-member.md) | Forbid use of exported name as property of default export.                            |                                                              | ☑️ 🚸 !\[badge-flat/recommended]\[] !\[badge-flat/warnings]\[] |     |     |     |     |
+| [no-rename-default](docs/rules/no-rename-default.md)                   | Forbid importing a default export by a different name.                                |                                                              | 🚸 !\[badge-flat/warnings]\[]                                  |     |     |     |     |
+| [no-unused-modules](docs/rules/no-unused-modules.md)                   | Forbid modules without exports, or exports without matching import in another module. |                                                              |                                                                |     |     |     |     |
 
 ### Module systems
 
@@ -254,45 +254,45 @@ settings:
 
 ### Static analysis
 
-| Name                                                                   | Description                                                                          | 💼    | ⚠️  | 🚫  | 🔧  | 💡  | ❌  |
-| :--------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :---- | :-- | :-- | :-- | :-- | :-- |
-| [default](docs/rules/default.md)                                       | Ensure a default export is present, given a default import.                          | ❗ ☑️ |     |     |     |     |     |
-| [named](docs/rules/named.md)                                           | Ensure named imports correspond to a named export in the remote file.                | ❗ ☑️ |     | ⌨️  |     |     |     |
-| [namespace](docs/rules/namespace.md)                                   | Ensure imported namespaces contain dereferenced properties as they are dereferenced. | ❗ ☑️ |     |     |     |     |     |
-| [no-absolute-path](docs/rules/no-absolute-path.md)                     | Forbid import of modules using absolute paths.                                       |       |     |     | 🔧  |     |     |
-| [no-cycle](docs/rules/no-cycle.md)                                     | Forbid a module from importing a module with a dependency path back to itself.       |       |     |     |     |     |     |
-| [no-dynamic-require](docs/rules/no-dynamic-require.md)                 | Forbid `require()` calls with expressions.                                           |       |     |     |     |     |     |
-| [no-internal-modules](docs/rules/no-internal-modules.md)               | Forbid importing the submodules of other modules.                                    |       |     |     |     |     |     |
-| [no-relative-packages](docs/rules/no-relative-packages.md)             | Forbid importing packages through relative paths.                                    |       |     |     | 🔧  |     |     |
-| [no-relative-parent-imports](docs/rules/no-relative-parent-imports.md) | Forbid importing modules from parent directories.                                    |       |     |     |     |     |     |
-| [no-restricted-paths](docs/rules/no-restricted-paths.md)               | Enforce which files can be imported in a given folder.                               |       |     |     |     |     |     |
-| [no-self-import](docs/rules/no-self-import.md)                         | Forbid a module from importing itself.                                               |       |     |     |     |     |     |
-| [no-unresolved](docs/rules/no-unresolved.md)                           | Ensure imports point to a file/module that can be resolved.                          | ❗ ☑️ |     |     |     |     |     |
-| [no-useless-path-segments](docs/rules/no-useless-path-segments.md)     | Forbid unnecessary path segments in import and require statements.                   |       |     |     | 🔧  |     |     |
-| [no-webpack-loader-syntax](docs/rules/no-webpack-loader-syntax.md)     | Forbid webpack loader syntax in imports.                                             |       |     |     |     |     |     |
+| Name                                                                   | Description                                                                          | 💼                                                           | ⚠️  | 🚫                              | 🔧  | 💡  | ❌  |
+| :--------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :----------------------------------------------------------- | :-- | :------------------------------ | :-- | :-- | :-- |
+| [default](docs/rules/default.md)                                       | Ensure a default export is present, given a default import.                          | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |     |                                 |     |     |     |
+| [named](docs/rules/named.md)                                           | Ensure named imports correspond to a named export in the remote file.                | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |     | ⌨️ !\[badge-flat/typescript]\[] |     |     |     |
+| [namespace](docs/rules/namespace.md)                                   | Ensure imported namespaces contain dereferenced properties as they are dereferenced. | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |     |                                 |     |     |     |
+| [no-absolute-path](docs/rules/no-absolute-path.md)                     | Forbid import of modules using absolute paths.                                       |                                                              |     |                                 | 🔧  |     |     |
+| [no-cycle](docs/rules/no-cycle.md)                                     | Forbid a module from importing a module with a dependency path back to itself.       |                                                              |     |                                 |     |     |     |
+| [no-dynamic-require](docs/rules/no-dynamic-require.md)                 | Forbid `require()` calls with expressions.                                           |                                                              |     |                                 |     |     |     |
+| [no-internal-modules](docs/rules/no-internal-modules.md)               | Forbid importing the submodules of other modules.                                    |                                                              |     |                                 |     |     |     |
+| [no-relative-packages](docs/rules/no-relative-packages.md)             | Forbid importing packages through relative paths.                                    |                                                              |     |                                 | 🔧  |     |     |
+| [no-relative-parent-imports](docs/rules/no-relative-parent-imports.md) | Forbid importing modules from parent directories.                                    |                                                              |     |                                 |     |     |     |
+| [no-restricted-paths](docs/rules/no-restricted-paths.md)               | Enforce which files can be imported in a given folder.                               |                                                              |     |                                 |     |     |     |
+| [no-self-import](docs/rules/no-self-import.md)                         | Forbid a module from importing itself.                                               |                                                              |     |                                 |     |     |     |
+| [no-unresolved](docs/rules/no-unresolved.md)                           | Ensure imports point to a file/module that can be resolved.                          | ❗ ☑️ !\[badge-flat/errors]\[] !\[badge-flat/recommended]\[] |     |                                 |     |     |     |
+| [no-useless-path-segments](docs/rules/no-useless-path-segments.md)     | Forbid unnecessary path segments in import and require statements.                   |                                                              |     |                                 | 🔧  |     |     |
+| [no-webpack-loader-syntax](docs/rules/no-webpack-loader-syntax.md)     | Forbid webpack loader syntax in imports.                                             |                                                              |     |                                 |     |     |     |
 
 ### Style guide
 
-| Name                                                                             | Description                                                                 | 💼  | ⚠️    | 🚫  | 🔧  | 💡  | ❌  |
-| :------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :-- | :---- | :-- | :-- | :-- | :-- |
-| [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports.       |     |       |     | 🔧  |     |     |
-| [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.    |     |       |     |     | 💡  |     |
-| [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                           |     |       |     |     |     |     |
-| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.             |     |       |     | 🔧  | 💡  |     |
-| [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                          |     |       |     | 🔧  |     |     |
-| [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration. |     |       |     |     |     |     |
-| [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import-x/first`.                                               |     |       |     | 🔧  |     | ❌  |
-| [max-dependencies](docs/rules/max-dependencies.md)                               | Enforce the maximum number of dependencies a module can have.               |     |       |     |     |     |     |
-| [newline-after-import](docs/rules/newline-after-import.md)                       | Enforce a newline after import statements.                                  |     |       |     | 🔧  |     |     |
-| [no-anonymous-default-export](docs/rules/no-anonymous-default-export.md)         | Forbid anonymous values as default exports.                                 |     |       |     |     |     |     |
-| [no-default-export](docs/rules/no-default-export.md)                             | Forbid default exports.                                                     |     |       |     |     |     |     |
-| [no-duplicates](docs/rules/no-duplicates.md)                                     | Forbid repeated import of the same module in multiple places.               |     | ☑️ 🚸 |     | 🔧  |     |     |
-| [no-named-default](docs/rules/no-named-default.md)                               | Forbid named default exports.                                               |     |       |     |     |     |     |
-| [no-named-export](docs/rules/no-named-export.md)                                 | Forbid named exports.                                                       |     |       |     |     |     |     |
-| [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                           |     |       |     | 🔧  |     |     |
-| [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports.                                                  |     |       |     |     |     |     |
-| [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                                |     |       |     | 🔧  |     |     |
-| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names.  |     |       |     |     |     |     |
+| Name                                                                             | Description                                                                 | 💼  | ⚠️                                                             | 🚫  | 🔧  | 💡  | ❌  |
+| :------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :-- | :------------------------------------------------------------- | :-- | :-- | :-- | :-- |
+| [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports.       |     |                                                                |     | 🔧  |     |     |
+| [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.    |     |                                                                |     |     | 💡  |     |
+| [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                           |     |                                                                |     |     |     |     |
+| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.             |     |                                                                |     | 🔧  | 💡  |     |
+| [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                          |     |                                                                |     | 🔧  |     |     |
+| [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration. |     |                                                                |     |     |     |     |
+| [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import-x/first`.                                               |     |                                                                |     | 🔧  |     | ❌  |
+| [max-dependencies](docs/rules/max-dependencies.md)                               | Enforce the maximum number of dependencies a module can have.               |     |                                                                |     |     |     |     |
+| [newline-after-import](docs/rules/newline-after-import.md)                       | Enforce a newline after import statements.                                  |     |                                                                |     | 🔧  |     |     |
+| [no-anonymous-default-export](docs/rules/no-anonymous-default-export.md)         | Forbid anonymous values as default exports.                                 |     |                                                                |     |     |     |     |
+| [no-default-export](docs/rules/no-default-export.md)                             | Forbid default exports.                                                     |     |                                                                |     |     |     |     |
+| [no-duplicates](docs/rules/no-duplicates.md)                                     | Forbid repeated import of the same module in multiple places.               |     | ☑️ 🚸 !\[badge-flat/recommended]\[] !\[badge-flat/warnings]\[] |     | 🔧  |     |     |
+| [no-named-default](docs/rules/no-named-default.md)                               | Forbid named default exports.                                               |     |                                                                |     |     |     |     |
+| [no-named-export](docs/rules/no-named-export.md)                                 | Forbid named exports.                                                       |     |                                                                |     |     |     |     |
+| [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                           |     |                                                                |     | 🔧  |     |     |
+| [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports.                                                  |     |                                                                |     |     |     |     |
+| [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                                |     |                                                                |     | 🔧  |     |     |
+| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names.  |     |                                                                |     |     |     |     |
 
 <!-- end auto-generated rules list -->
 
@@ -321,7 +321,7 @@ You can reference resolvers in several ways (in order of precedence):
 
 ### `import-x/resolver-next`
 
-> [!warning]
+> \[!warning]
 >
 > Only available in the new flat config system. If you are using the legacy config system, please use `import-x/resolver` instead.
 

--- a/docs/rules/default.md
+++ b/docs/rules/default.md
@@ -1,6 +1,6 @@
 # import-x/default
 
-💼 This rule is enabled in the following configs: ❗ `errors`, ☑️ `recommended`.
+💼 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/default.md
+++ b/docs/rules/default.md
@@ -1,6 +1,6 @@
 # import-x/default
 
-💼 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`.
+💼 This rule is enabled in the following configs: ❗ `errors`, ❗ `flat/errors`, ☑️ `flat/recommended`, ☑️ `recommended`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/export.md
+++ b/docs/rules/export.md
@@ -1,6 +1,6 @@
 # import-x/export
 
-💼 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`.
+💼 This rule is enabled in the following configs: ❗ `errors`, ❗ `flat/errors`, ☑️ `flat/recommended`, ☑️ `recommended`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/export.md
+++ b/docs/rules/export.md
@@ -1,6 +1,6 @@
 # import-x/export
 
-💼 This rule is enabled in the following configs: ❗ `errors`, ☑️ `recommended`.
+💼 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/named.md
+++ b/docs/rules/named.md
@@ -1,6 +1,6 @@
 # import-x/named
 
-💼🚫 This rule is enabled in the following configs: ❗ `errors`, ☑️ `recommended`. This rule is _disabled_ in the ⌨️ `typescript` config.
+💼🚫 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`. This rule is _disabled_ in the following configs: `flat/typescript`, ⌨️ `typescript`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/named.md
+++ b/docs/rules/named.md
@@ -1,6 +1,6 @@
 # import-x/named
 
-💼🚫 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`. This rule is _disabled_ in the following configs: `flat/typescript`, ⌨️ `typescript`.
+💼🚫 This rule is enabled in the following configs: ❗ `errors`, ❗ `flat/errors`, ☑️ `flat/recommended`, ☑️ `recommended`. This rule is _disabled_ in the following configs: ⌨️ `flat/typescript`, ⌨️ `typescript`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/namespace.md
+++ b/docs/rules/namespace.md
@@ -1,6 +1,6 @@
 # import-x/namespace
 
-💼 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`.
+💼 This rule is enabled in the following configs: ❗ `errors`, ❗ `flat/errors`, ☑️ `flat/recommended`, ☑️ `recommended`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/namespace.md
+++ b/docs/rules/namespace.md
@@ -1,6 +1,6 @@
 # import-x/namespace
 
-💼 This rule is enabled in the following configs: ❗ `errors`, ☑️ `recommended`.
+💼 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -1,7 +1,5 @@
 # import-x/no-deprecated
 
-⚠️ This rule _warns_ in the `flat/stage-0` config.
-
 <!-- end auto-generated rule header -->
 
 Reports use of a deprecated name, as indicated by a JSDoc block with a `@deprecated`

--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -1,5 +1,7 @@
 # import-x/no-deprecated
 
+⚠️ This rule _warns_ in the `flat/stage-0` config.
+
 <!-- end auto-generated rule header -->
 
 Reports use of a deprecated name, as indicated by a JSDoc block with a `@deprecated`

--- a/docs/rules/no-duplicates.md
+++ b/docs/rules/no-duplicates.md
@@ -1,6 +1,6 @@
 # import-x/no-duplicates
 
-⚠️ This rule _warns_ in the following configs: ☑️ `recommended`, 🚸 `warnings`.
+⚠️ This rule _warns_ in the following configs: `flat/recommended`, `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-duplicates.md
+++ b/docs/rules/no-duplicates.md
@@ -1,6 +1,6 @@
 # import-x/no-duplicates
 
-⚠️ This rule _warns_ in the following configs: `flat/recommended`, `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
+⚠️ This rule _warns_ in the following configs: ☑️ `flat/recommended`, 🚸 `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-named-as-default-member.md
+++ b/docs/rules/no-named-as-default-member.md
@@ -1,6 +1,6 @@
 # import-x/no-named-as-default-member
 
-⚠️ This rule _warns_ in the following configs: ☑️ `recommended`, 🚸 `warnings`.
+⚠️ This rule _warns_ in the following configs: `flat/recommended`, `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-named-as-default-member.md
+++ b/docs/rules/no-named-as-default-member.md
@@ -1,6 +1,6 @@
 # import-x/no-named-as-default-member
 
-⚠️ This rule _warns_ in the following configs: `flat/recommended`, `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
+⚠️ This rule _warns_ in the following configs: ☑️ `flat/recommended`, 🚸 `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-named-as-default.md
+++ b/docs/rules/no-named-as-default.md
@@ -1,6 +1,6 @@
 # import-x/no-named-as-default
 
-⚠️ This rule _warns_ in the following configs: `flat/recommended`, `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
+⚠️ This rule _warns_ in the following configs: ☑️ `flat/recommended`, 🚸 `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-named-as-default.md
+++ b/docs/rules/no-named-as-default.md
@@ -1,6 +1,6 @@
 # import-x/no-named-as-default
 
-⚠️ This rule _warns_ in the following configs: ☑️ `recommended`, 🚸 `warnings`.
+⚠️ This rule _warns_ in the following configs: `flat/recommended`, `flat/warnings`, ☑️ `recommended`, 🚸 `warnings`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-rename-default.md
+++ b/docs/rules/no-rename-default.md
@@ -1,6 +1,6 @@
 # import-x/no-rename-default
 
-⚠️ This rule _warns_ in the following configs: `flat/warnings`, 🚸 `warnings`.
+⚠️ This rule _warns_ in the following configs: 🚸 `flat/warnings`, 🚸 `warnings`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-rename-default.md
+++ b/docs/rules/no-rename-default.md
@@ -1,6 +1,6 @@
 # import-x/no-rename-default
 
-⚠️ This rule _warns_ in the 🚸 `warnings` config.
+⚠️ This rule _warns_ in the following configs: `flat/warnings`, 🚸 `warnings`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-unresolved.md
+++ b/docs/rules/no-unresolved.md
@@ -1,6 +1,6 @@
 # import-x/no-unresolved
 
-💼 This rule is enabled in the following configs: ❗ `errors`, ☑️ `recommended`.
+💼 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-unresolved.md
+++ b/docs/rules/no-unresolved.md
@@ -1,6 +1,6 @@
 # import-x/no-unresolved
 
-💼 This rule is enabled in the following configs: ❗ `errors`, `flat/errors`, `flat/recommended`, ☑️ `recommended`.
+💼 This rule is enabled in the following configs: ❗ `errors`, ❗ `flat/errors`, ☑️ `flat/recommended`, ☑️ `recommended`.
 
 <!-- end auto-generated rule header -->
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "release": "clean-pkg-json && changeset publish",
     "test": "node --experimental-vm-modules --no-warnings=ESLintRCWarning node_modules/jest/bin/jest.js",
     "test-compiled": "yarn build && TEST_COMPILED=1 yarn test",
-    "update:eslint-docs": "eslint-doc-generator --rule-doc-title-format prefix-name --rule-doc-section-options false --rule-list-split meta.docs.category --ignore-config stage-0 --config-emoji recommended,☑️",
+    "update:eslint-docs": "eslint-doc-generator",
     "watch": "yarn test --watch"
   },
   "peerDependencies": {

--- a/patches/eslint-doc-generator+2.1.2.patch
+++ b/patches/eslint-doc-generator+2.1.2.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/eslint-doc-generator/dist/lib/option-parsers.js b/node_modules/eslint-doc-generator/dist/lib/option-parsers.js
+index 556ff0d..0361b02 100644
+--- a/node_modules/eslint-doc-generator/dist/lib/option-parsers.js
++++ b/node_modules/eslint-doc-generator/dist/lib/option-parsers.js
+@@ -27,9 +27,9 @@ export function parseConfigEmojiOptions(plugin, configEmoji) {
+         if (plugin.configs?.[config] === undefined) {
+             throw new Error(`Invalid configEmoji option: ${config} config not found.`);
+         }
+-        if (RESERVED_EMOJIS.includes(emoji)) {
+-            throw new Error(`Cannot specify reserved emoji ${EMOJI_CONFIG_ERROR}.`);
+-        }
++        // if (RESERVED_EMOJIS.includes(emoji)) {
++        //     throw new Error(`Cannot specify reserved emoji ${EMOJI_CONFIG_ERROR}.`);
++        // }
+         return [{ config, emoji }];
+     }) || [];
+     // Add default emojis for the common configs for which the user hasn't already specified an emoji.

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,33 +131,14 @@ const rules = {
   'imports-first': importsFirst,
 } satisfies Record<string, TSESLint.RuleModule<string, readonly unknown[]>>
 
-const configs = {
-  recommended,
-
-  errors,
-  warnings,
-
-  // shhhh... work in progress "secret" rules
-  'stage-0': stage0,
-
-  // useful stuff for folks using various environments
-  react,
-  'react-native': reactNative,
-  electron,
-  typescript,
-} satisfies Record<string, PluginConfig>
-
 // Base Plugin Object
 const plugin_ = {
   meta,
-  configs,
   rules,
   cjsRequire,
   importXResolverCompat,
   createNodeResolver,
 }
-
-const plugin = plugin_ as typeof plugin_ & { flatConfigs: typeof flatConfigs }
 
 // Create flat configs (Only ones that declare plugins and parser options need to be different from the legacy config)
 const createFlatConfig = (
@@ -166,7 +147,7 @@ const createFlatConfig = (
 ): PluginFlatConfig => ({
   ...baseConfig,
   name: `import-x/${configName}`,
-  plugins: { 'import-x': plugin },
+  plugins: { 'import-x': plugin_ },
 })
 
 const flatConfigs = {
@@ -185,7 +166,38 @@ const flatConfigs = {
   typescript: createFlatConfig(typescriptFlat, 'typescript'),
 } satisfies Record<string, PluginFlatConfig>
 
+const configs = {
+  recommended,
+
+  errors,
+  warnings,
+
+  // shhhh... work in progress "secret" rules
+  'stage-0': stage0,
+
+  // useful stuff for folks using various environments
+  react,
+  'react-native': reactNative,
+  electron,
+  typescript,
+
+  'flat/recommended': flatConfigs.recommended,
+  'flat/errors': flatConfigs.errors,
+  'flat/warnings': flatConfigs.warnings,
+  'flat/stage-0': flatConfigs['stage-0'],
+  'flat/react': flatConfigs.react,
+  'flat/react-native': flatConfigs['react-native'],
+  'flat/electron': flatConfigs.electron,
+  'flat/typescript': flatConfigs.typescript,
+} satisfies Record<string, PluginConfig | PluginFlatConfig>
+
+const plugin = plugin_ as typeof plugin_ & {
+  flatConfigs: typeof flatConfigs
+  configs: typeof configs
+}
+
 plugin.flatConfigs = flatConfigs
+plugin.configs = configs
 
 export default plugin
 


### PR DESCRIPTION
ESLint doesn't understand what `flatConfigs` is, the actual config object is `configs`. So we need to expose the flat configs there in order for ESLint's `extends` logic to work properly.

This means `extends: ['import-x/flat/recommended']` will now work.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Expose flat configurations in `configs` object to support ESLint `extends` logic, with documentation updates and configuration emojis.
> 
>   - **Behavior**:
>     - Expose flat configurations in `configs` object in `src/index.ts` to support ESLint `extends` logic.
>     - `extends: ['import-x/flat/recommended']` now works.
>   - **Documentation**:
>     - Update `README.md` to include examples using `defineConfig` with flat configurations.
>     - Update rule documentation in `docs/rules/*.md` to reflect new flat configuration presets.
>   - **Misc**:
>     - Add configuration emojis for flat configs in `.eslint-doc-generatorrc.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for e5e1de594c09608e55aebd49937350f2cb6be8ff. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exposed flat ESLint configuration objects, making it easier to extend and reference plugin configurations.
- **Documentation**
  - Updated documentation and rule tables to reflect expanded support for flat configs and clarified which rules are enabled in each configuration.
  - Added examples for using the new flat configs and updated badge symbols for easier identification.
- **Chores**
  - Updated configuration files and scripts to simplify and improve documentation generation and configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->