### PR TITLE
fix: tslib is no longer used because we're targeting ES2022

### DIFF
--- a/.changeset/grumpy-starfishes-double.md
+++ b/.changeset/grumpy-starfishes-double.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: tslib is no longer used because we're targeting ES2022

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "minimatch": "^9.0.3 || ^10.0.1",
     "semver": "^7.7.2",
     "stable-hash": "^0.0.5",
-    "tslib": "^2.8.1",
     "unrs-resolver": "^1.7.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5977,7 +5977,6 @@ __metadata:
     tinyexec: "npm:^1.0.1"
     ts-node: "npm:^10.9.2"
     tsdown: "npm:^0.12.3"
-    tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.32.1"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `tslib` from `dependencies` in `package.json` as it's unnecessary for ES2022 target.
> 
>   - **Dependencies**:
>     - Remove `tslib` from `dependencies` in `package.json` as it's no longer needed for ES2022 target.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 49a9e7b2b6d92f9db39ca31b69e164df8a3c5a78. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the "tslib" dependency from the project.
  - Updated documentation to reflect that "tslib" is no longer required due to ES2022 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->