### PR TITLE
fix: do not consider resolved path in extensions rule

### DIFF
--- a/src/rules/extensions.ts
+++ b/src/rules/extensions.ts
@@ -329,8 +329,8 @@ export default createRule<Options, MessageId>({
         const resolvedPath = resolve(importPath, context)
 
         const extension =
-          path.extname(importPath)?.slice?.(1) ||
-          path.extname(resolvedPath).slice(1)
+          path.extname(importPath).slice(1) ||
+          (resolvedPath ? path.extname(resolvedPath).slice(1) : '')
 
         // determine if this is a module
         const isPackage =


### PR DESCRIPTION
I just ran into the following issue:

I'm migrating to TypeScript and I have `import foo from './foo.js';` in a file and there is `foo.ts`. I also have `'import-x/extensions': ['error', 'ignorePackages', { js: 'never', ts: 'never' }]` configured so that the dev omits `.js`and then the resolver will correctly resolve `foo.ts`. But this is not the case because eslint-plugin-import-x will only suggest to omit the extension if the extension of the import statement is equal to the resolved path.

My suggestion is to not `||` the paths but the extensions. So, if the import path has an extension, take this, otherwise take the one from the resolved path.

Yeah, I think the solution isn't ideal yet, there are failing tests. Maybe someone can help with it.

EDIT: Closed in favor of `extensionAlias` option from eslint-import-resolver-typescript which prevents the case where import path and resolved path are not aligned.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change extension determination in `extensions.ts` to use `importPath` directly, affecting ESLint extension rules in TypeScript projects.
> 
>   - **Behavior**:
>     - In `extensions.ts`, change extension determination to use `importPath` directly instead of `resolvedPath`.
>     - Affects ESLint rule for extensions, particularly in TypeScript projects where import and resolved paths differ.
>   - **Functions**:
>     - Modify `createRule` in `extensions.ts` to use `path.extname(importPath).slice(1)` for extension extraction.
>   - **Misc**:
>     - Remove unused `resolvedPath` variable in `extensions.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 5a078d53141392a6dfd5b119ec46c8dc50857c26. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the process for extracting file extensions from import paths, improving efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->