### PR TITLE
docs: adopt DeprecatedInfo

### DIFF
--- a/src/rules/imports-first.ts
+++ b/src/rules/imports-first.ts
@@ -1,4 +1,4 @@
-import { createRule } from '../utils/index.js'
+import { createRule, docsUrl } from '../utils/index.js'
 
 import first from './first.js'
 
@@ -7,7 +7,16 @@ export default createRule({
   name: 'imports-first',
   meta: {
     ...first.meta,
-    deprecated: true,
+    deprecated: {
+      message: 'Replaced by `import-x/first`.',
+      url: 'https://github.com/import-js/eslint-plugin-import/blob/main/CHANGELOG.md#changed-24',
+      deprecatedSince: '2.0.0',
+      replacedBy: [
+        {
+          rule: { name: 'first', url: docsUrl('first') },
+        },
+      ],
+    },
     docs: {
       category: 'Style guide',
       description: 'Replaced by `import-x/first`.',


### PR DESCRIPTION
Hey there,

this is just a minor fix which updates the metadata of `imports-first` according to [DeprecatedInfo](https://github.com/eslint/rewrite/blob/2dbe2b9c9431997bb4a1ab0335d8101564b62a41/packages/core/src/types.ts#L207) in [@eslint/core](https://github.com/eslint/rewrite/blob/main/packages/core/package.json) or rather [@typescript-eslint/utils](https://github.com/typescript-eslint/typescript-eslint/blob/1e0ba6253cdecbbb69b37537599aad9a21ed310e/packages/utils/src/ts-eslint/Rule.ts#L61)