### PR TITLE
fix: pnp issue when used in a monorepo

### DIFF
--- a/src/utils/module-require.ts
+++ b/src/utils/module-require.ts
@@ -1,7 +1,8 @@
-import Module from 'node:module'
+import Module, { createRequire } from 'node:module'
 import path from 'node:path'
 
 import { cjsRequire } from '../require.js'
+import type { ChildContext, RuleContext } from '../types.js'
 
 function createModule(filename: string) {
   const mod = new Module(filename)
@@ -11,7 +12,10 @@ function createModule(filename: string) {
   return mod
 }
 
-export function moduleRequire<T>(p: string): T {
+export function moduleRequire<T>(
+  p: string,
+  context: ChildContext | RuleContext,
+): T {
   try {
     // attempt to get espree relative to eslint
     const eslintPath = cjsRequire.resolve('eslint')
@@ -28,6 +32,13 @@ export function moduleRequire<T>(p: string): T {
   try {
     // try relative to entry point
     return cjsRequire.main!.require(p)
+  } catch {
+    //
+  }
+
+  try {
+    // try relative to the current context
+    return createRequire(context.physicalFilename)(p)
   } catch {
     //
   }

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -117,7 +117,7 @@ export function parse(
   // require the parser relative to the main module (i.e., ESLint)
   const parser =
     typeof parserOrPath === 'string'
-      ? moduleRequire<TSESLint.Parser.ParserModule>(parserOrPath)
+      ? moduleRequire<TSESLint.Parser.ParserModule>(parserOrPath, context)
       : parserOrPath
 
   // replicate bom strip and hashbang transform of ESLint

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -300,7 +300,7 @@ function fullResolve(
 
     for (const { enable, name, options, resolver } of normalizeConfigResolvers(
       configResolvers,
-      sourceFile,
+      context.physicalFilename,
     )) {
       if (!enable) {
         continue


### PR DESCRIPTION
Always use the file being linted as the "location" of the require when loading a resolver for the file. This prevents an issue when the sourceFile is in a dependency of the package being linted.
Add a fallback when loading a parser, the fallback uses the file being linted as the location of the require.

Using the file being linted isn't perfect because a user might configure the linter to lint files in other packages. However the approach is better than what was before.

All of the existing tests are passing. I don't time to figure out how to add a test specific to this change. I think the test code would have to be run in a PnP repo that has the top level fallback disabled.