### PR TITLE
feat: port `react-x/prefer-react-namespace-import` into `prefer-namespace-import`

### DIFF
--- a/.changeset/light-llamas-return.md
+++ b/.changeset/light-llamas-return.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": minor
+---
+
+feat: port [`react-x/prefer-react-namespace-import`](https://eslint-react.xyz/docs/rules/prefer-react-namespace-import) into `prefer-namespace-import`

--- a/README.md
+++ b/README.md
@@ -253,10 +253,6 @@ settings:
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).\
 ❌ Deprecated.
 
-| Name                                                             | Description                                            | 💼  | ⚠️  | 🚫  | 🔧  | 💡  | ❌  |
-| :--------------------------------------------------------------- | :----------------------------------------------------- | :-- | :-- | :-- | :-- | :-- | :-- |
-| [prefer-namespace-import](docs/rules/prefer-namespace-import.md) | Enforces using namespace imports for specific modules. |     |     |     | 🔧  |     |     |
-
 ### Helpful warnings
 
 | Name                                                                   | Description                                                                           | 💼          | ⚠️          | 🚫  | 🔧  | 💡  | ❌  |
@@ -302,26 +298,27 @@ settings:
 
 ### Style guide
 
-| Name                                                                             | Description                                                                 | 💼  | ⚠️          | 🚫  | 🔧  | 💡  | ❌  |
-| :------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :-- | :---------- | :-- | :-- | :-- | :-- |
-| [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports.       |     |             |     | 🔧  |     |     |
-| [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.    |     |             |     |     | 💡  |     |
-| [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                           |     |             |     |     |     |     |
-| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.             |     |             |     | 🔧  | 💡  |     |
-| [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                          |     |             |     | 🔧  |     |     |
-| [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration. |     |             |     |     |     |     |
-| [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import-x/first`.                                               |     |             |     | 🔧  |     | ❌  |
-| [max-dependencies](docs/rules/max-dependencies.md)                               | Enforce the maximum number of dependencies a module can have.               |     |             |     |     |     |     |
-| [newline-after-import](docs/rules/newline-after-import.md)                       | Enforce a newline after import statements.                                  |     |             |     | 🔧  |     |     |
-| [no-anonymous-default-export](docs/rules/no-anonymous-default-export.md)         | Forbid anonymous values as default exports.                                 |     |             |     |     |     |     |
-| [no-default-export](docs/rules/no-default-export.md)                             | Forbid default exports.                                                     |     |             |     |     |     |     |
-| [no-duplicates](docs/rules/no-duplicates.md)                                     | Forbid repeated import of the same module in multiple places.               |     | ☑️ 🚸 ☑️ 🚸 |     | 🔧  |     |     |
-| [no-named-default](docs/rules/no-named-default.md)                               | Forbid named default exports.                                               |     |             |     |     |     |     |
-| [no-named-export](docs/rules/no-named-export.md)                                 | Forbid named exports.                                                       |     |             |     |     |     |     |
-| [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                           |     |             |     | 🔧  |     |     |
-| [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports.                                                  |     |             |     |     |     |     |
-| [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                                |     |             |     | 🔧  |     |     |
-| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names.  |     |             |     |     |     |     |
+| Name                                                                             | Description                                                                          | 💼  | ⚠️          | 🚫  | 🔧  | 💡  | ❌  |
+| :------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :-- | :---------- | :-- | :-- | :-- | :-- |
+| [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports.                |     |             |     | 🔧  |     |     |
+| [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.             |     |             |     |     | 💡  |     |
+| [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                                    |     |             |     |     |     |     |
+| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.                      |     |             |     | 🔧  | 💡  |     |
+| [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                                   |     |             |     | 🔧  |     |     |
+| [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration.          |     |             |     |     |     |     |
+| [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import-x/first`.                                                        |     |             |     | 🔧  |     | ❌  |
+| [max-dependencies](docs/rules/max-dependencies.md)                               | Enforce the maximum number of dependencies a module can have.                        |     |             |     |     |     |     |
+| [newline-after-import](docs/rules/newline-after-import.md)                       | Enforce a newline after import statements.                                           |     |             |     | 🔧  |     |     |
+| [no-anonymous-default-export](docs/rules/no-anonymous-default-export.md)         | Forbid anonymous values as default exports.                                          |     |             |     |     |     |     |
+| [no-default-export](docs/rules/no-default-export.md)                             | Forbid default exports.                                                              |     |             |     |     |     |     |
+| [no-duplicates](docs/rules/no-duplicates.md)                                     | Forbid repeated import of the same module in multiple places.                        |     | ☑️ 🚸 ☑️ 🚸 |     | 🔧  |     |     |
+| [no-named-default](docs/rules/no-named-default.md)                               | Forbid named default exports.                                                        |     |             |     |     |     |     |
+| [no-named-export](docs/rules/no-named-export.md)                                 | Forbid named exports.                                                                |     |             |     |     |     |     |
+| [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                                    |     |             |     | 🔧  |     |     |
+| [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports.                                                           |     |             |     |     |     |     |
+| [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                                         |     |             |     | 🔧  |     |     |
+| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names.           |     |             |     |     |     |     |
+| [prefer-namespace-import](docs/rules/prefer-namespace-import.md)                 | Enforce using namespace imports for specific modules, like `react`/`react-dom`, etc. |     |             |     | 🔧  |     |     |
 
 <!-- end auto-generated rules list -->
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ settings:
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).\
 ❌ Deprecated.
 
+| Name                                                             | Description                                            | 💼  | ⚠️  | 🚫  | 🔧  | 💡  | ❌  |
+| :--------------------------------------------------------------- | :----------------------------------------------------- | :-- | :-- | :-- | :-- | :-- | :-- |
+| [prefer-namespace-import](docs/rules/prefer-namespace-import.md) | Enforces using namespace imports for specific modules. |     |     |     | 🔧  |     |     |
+
 ### Helpful warnings
 
 | Name                                                                   | Description                                                                           | 💼          | ⚠️          | 🚫  | 🔧  | 💡  | ❌  |

--- a/docs/rules/prefer-namespace-import.md
+++ b/docs/rules/prefer-namespace-import.md
@@ -1,0 +1,46 @@
+# import-x/prefer-namespace-import
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+Enforces specific modules are imported via namespace imports, like `react`/`react-dom`, etc.
+
+## Rule Details
+
+### rule schema
+
+```jsonc
+{
+  "import-x/prefer-namespace-import": [
+    "error", // or "off", "warn"
+    {
+      "patterns": [
+        // Exact match
+        "foo",
+        // RegExp
+        "/^prefix-/",
+      ],
+    },
+  ],
+}
+```
+
+### Config Options
+
+`patterns` is an array of strings or `RegExp` patterns that specify which modules should be imported using namespace imports.
+
+#### Example
+
+```js
+/*eslint import-x/prefer-namespace-import: [2, { patterns: ['react'] }]*/
+
+// bad
+import React from 'react'
+
+// good
+import * as React from 'react'
+
+// ignored
+import ReactDOM from 'react-dom'
+```

--- a/docs/rules/prefer-namespace-import.md
+++ b/docs/rules/prefer-namespace-import.md
@@ -4,7 +4,7 @@
 
 <!-- end auto-generated rule header -->
 
-Enforces specific modules are imported via namespace imports, like `react`/`react-dom`, etc.
+Enforce using namespace imports for specific modules, like `react`/`react-dom`, etc.
 
 ## Rule Details
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ import noUselessPathSegments from './rules/no-useless-path-segments.js'
 import noWebpackLoaderSyntax from './rules/no-webpack-loader-syntax.js'
 import order from './rules/order.js'
 import preferDefaultExport from './rules/prefer-default-export.js'
-import preferNamespaceImport from "./rules/prefer-namespace-import.js"
+import preferNamespaceImport from './rules/prefer-namespace-import.js'
 import unambiguous from './rules/unambiguous.js'
 // configs
 import type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ import noUselessPathSegments from './rules/no-useless-path-segments.js'
 import noWebpackLoaderSyntax from './rules/no-webpack-loader-syntax.js'
 import order from './rules/order.js'
 import preferDefaultExport from './rules/prefer-default-export.js'
+import preferNamespaceImport from "./rules/prefer-namespace-import.js"
 import unambiguous from './rules/unambiguous.js'
 // configs
 import type {
@@ -111,6 +112,7 @@ const rules = {
   order,
   'newline-after-import': newlineAfterImport,
   'prefer-default-export': preferDefaultExport,
+  'prefer-namespace-import': preferNamespaceImport,
   'no-default-export': noDefaultExport,
   'no-named-export': noNamedExport,
   'no-dynamic-require': noDynamicRequire,

--- a/src/rules/prefer-default-export.ts
+++ b/src/rules/prefer-default-export.ts
@@ -6,7 +6,7 @@ export interface Options {
   target?: 'single' | 'any'
 }
 
-type MessageId = 'single' | 'any'
+export type MessageId = 'single' | 'any'
 
 export default createRule<[Options?], MessageId>({
   name: 'prefer-default-export',

--- a/src/rules/prefer-namespace-import.ts
+++ b/src/rules/prefer-namespace-import.ts
@@ -1,0 +1,122 @@
+import type { TSESTree } from "@typescript-eslint/types";
+import type { RuleContext, RuleListener } from "@typescript-eslint/utils/ts-eslint";
+import { createRule } from '../utils/index.js'
+
+export const RULE_NAME = "prefer-namespace-import";
+
+type Options =  [
+  | undefined
+  | {
+    patterns?:  string[];
+  },
+];
+
+const defaultOptions = [{
+  patterns: [],
+}] as const satisfies Options;
+
+export type MessageID = "preferNamespaceImport";
+
+export default createRule<Options, MessageID>({
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforces using namespace imports for specific modules.",
+    },
+    fixable: "code",
+    messages: {
+      preferNamespaceImport: "Prefer importing {{specifier}} as 'import * as {{specifier}} from \"{{source}}\"';",
+    },
+    schema: [
+      {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          patterns: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+            uniqueItems: true,
+          },
+        },
+      },
+    ],
+  },
+  name: RULE_NAME,
+  create,
+  defaultOptions,
+});
+
+export function create(context: RuleContext<MessageID, Options>): RuleListener {
+  const patterns = context.options[0]?.patterns?.map((pattern) => toRegExp(pattern)) ?? [];
+  if (patterns.length === 0) return {};
+  return {
+    [`ImportDeclaration ImportDefaultSpecifier`](node: TSESTree.ImportDefaultSpecifier) {
+      const importSource = node.parent.source.value;
+      if (!patterns.some((pattern) => pattern.test(importSource))) return;
+      const defaultSpecifier = node.local.name;
+      const hasOtherSpecifiers = node.parent.specifiers.length > 1;
+      context.report({
+        messageId: "preferNamespaceImport",
+        node: hasOtherSpecifiers ? node : node.parent,
+        data: {
+          source: importSource,
+          specifier: defaultSpecifier,
+        },
+        fix(fixer) {
+          const importDeclarationText = context.sourceCode.getText(node.parent);
+          const semi = importDeclarationText.endsWith(";") ? ";" : "";
+          const quote = node.parent.source.raw.at(0) ?? "'";
+          const isTypeImport = node.parent.importKind === "type";
+          const importStringPrefix = `import${isTypeImport ? " type" : ""}`;
+          const importSourceQuoted = `${quote}${importSource}${quote}`;
+          if (!hasOtherSpecifiers) {
+            return fixer.replaceText(
+              node.parent,
+              `${importStringPrefix} * as ${node.local.name} from ${importSourceQuoted}${semi}`,
+            );
+          }
+          // dprint-ignore
+          // remove the default specifier and prepend the namespace import specifier
+          const specifiers = importDeclarationText.slice(importDeclarationText.indexOf("{"), importDeclarationText.indexOf("}") + 1);
+          return fixer.replaceText(
+            node.parent,
+            [
+              `${importStringPrefix} * as ${node.local.name} from ${importSourceQuoted}${semi}`,
+              `${importStringPrefix} ${specifiers} from ${importSourceQuoted}${semi}`,
+            ].join("\n"),
+          );
+        },
+      });
+    },
+  };
+}
+
+/**
+ * Regular expression for matching a RegExp string.
+ */
+const REGEXP_STR = /^\/(.+)\/([A-Za-z]*)$/u;
+
+/**
+ * Convert a string to the `RegExp`.
+ * Normal strings (e.g. `"foo"`) is converted to `/^foo$/` of `RegExp`.
+ * Strings like `"/^foo/i"` are converted to `/^foo/i` of `RegExp`.
+ * @see https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/utils/regexp.ts
+ * @param string The string to convert.
+ * @returns Returns the `RegExp`.
+ */
+function toRegExp(string: string): { test(s: string): boolean } {
+  const [, pattern, flags = "u"] = REGEXP_STR.exec(string) ?? [];
+  if (pattern != null) return new RegExp(pattern, flags);
+  return { test: (s) => s === string };
+}
+
+/**
+ * Checks whether given string is regexp string
+ * @param string The string to check
+ * @returns boolean
+ */
+// function isRegExp(string: string): boolean {
+//   return Boolean(REGEXP_STR.test(string));
+// }

--- a/src/rules/prefer-namespace-import.ts
+++ b/src/rules/prefer-namespace-import.ts
@@ -11,7 +11,9 @@ export default createRule<[Options?], MessageId>({
   meta: {
     type: 'problem',
     docs: {
-      description: 'Enforces using namespace imports for specific modules.',
+      category: 'Style guide',
+      description:
+        'Enforce using namespace imports for specific modules, like `react`/`react-dom`, etc.',
     },
     fixable: 'code',
     schema: [

--- a/src/rules/prefer-namespace-import.ts
+++ b/src/rules/prefer-namespace-import.ts
@@ -1,41 +1,47 @@
-import type { TSESTree } from "@typescript-eslint/types";
-import type { RuleContext, RuleListener } from "@typescript-eslint/utils/ts-eslint";
+import type { TSESTree } from '@typescript-eslint/types'
+import type {
+  RuleContext,
+  RuleListener,
+} from '@typescript-eslint/utils/ts-eslint'
 import { createRule } from '../utils/index.js'
 
-export const RULE_NAME = "prefer-namespace-import";
+export const RULE_NAME = 'prefer-namespace-import'
 
-type Options =  [
+type Options = [
   | undefined
   | {
-    patterns?:  string[];
+      patterns?: string[]
+    },
+]
+
+const defaultOptions = [
+  {
+    patterns: [],
   },
-];
+] as const satisfies Options
 
-const defaultOptions = [{
-  patterns: [],
-}] as const satisfies Options;
-
-export type MessageID = "preferNamespaceImport";
+export type MessageID = 'preferNamespaceImport'
 
 export default createRule<Options, MessageID>({
   meta: {
-    type: "problem",
+    type: 'problem',
     docs: {
-      description: "Enforces using namespace imports for specific modules.",
+      description: 'Enforces using namespace imports for specific modules.',
     },
-    fixable: "code",
+    fixable: 'code',
     messages: {
-      preferNamespaceImport: "Prefer importing {{specifier}} as 'import * as {{specifier}} from \"{{source}}\"';",
+      preferNamespaceImport:
+        'Prefer importing {{specifier}} as \'import * as {{specifier}} from "{{source}}"\';',
     },
     schema: [
       {
-        type: "object",
+        type: 'object',
         additionalProperties: false,
         properties: {
           patterns: {
-            type: "array",
+            type: 'array',
             items: {
-              type: "string",
+              type: 'string',
             },
             uniqueItems: true,
           },
@@ -46,76 +52,82 @@ export default createRule<Options, MessageID>({
   name: RULE_NAME,
   create,
   defaultOptions,
-});
+})
 
 export function create(context: RuleContext<MessageID, Options>): RuleListener {
-  const patterns = context.options[0]?.patterns?.map((pattern) => toRegExp(pattern)) ?? [];
-  if (patterns.length === 0) return {};
+  const patterns =
+    context.options[0]?.patterns?.map(pattern => toRegExp(pattern)) ?? []
+  if (patterns.length === 0) return {}
   return {
-    [`ImportDeclaration ImportDefaultSpecifier`](node: TSESTree.ImportDefaultSpecifier) {
-      const importSource = node.parent.source.value;
-      if (!patterns.some((pattern) => pattern.test(importSource))) return;
-      const defaultSpecifier = node.local.name;
-      const hasOtherSpecifiers = node.parent.specifiers.length > 1;
+    [`ImportDeclaration ImportDefaultSpecifier`](
+      node: TSESTree.ImportDefaultSpecifier,
+    ) {
+      const importSource = node.parent.source.value
+      if (!patterns.some(pattern => pattern.test(importSource))) return
+      const defaultSpecifier = node.local.name
+      const hasOtherSpecifiers = node.parent.specifiers.length > 1
       context.report({
-        messageId: "preferNamespaceImport",
+        messageId: 'preferNamespaceImport',
         node: hasOtherSpecifiers ? node : node.parent,
         data: {
           source: importSource,
           specifier: defaultSpecifier,
         },
         fix(fixer) {
-          const importDeclarationText = context.sourceCode.getText(node.parent);
-          const semi = importDeclarationText.endsWith(";") ? ";" : "";
-          const quote = node.parent.source.raw.at(0) ?? "'";
-          const isTypeImport = node.parent.importKind === "type";
-          const importStringPrefix = `import${isTypeImport ? " type" : ""}`;
-          const importSourceQuoted = `${quote}${importSource}${quote}`;
+          const importDeclarationText = context.sourceCode.getText(node.parent)
+          const semi = importDeclarationText.endsWith(';') ? ';' : ''
+          const quote = node.parent.source.raw.at(0) ?? "'"
+          const isTypeImport = node.parent.importKind === 'type'
+          const importStringPrefix = `import${isTypeImport ? ' type' : ''}`
+          const importSourceQuoted = `${quote}${importSource}${quote}`
           if (!hasOtherSpecifiers) {
             return fixer.replaceText(
               node.parent,
               `${importStringPrefix} * as ${node.local.name} from ${importSourceQuoted}${semi}`,
-            );
+            )
           }
           // dprint-ignore
           // remove the default specifier and prepend the namespace import specifier
-          const specifiers = importDeclarationText.slice(importDeclarationText.indexOf("{"), importDeclarationText.indexOf("}") + 1);
+          const specifiers = importDeclarationText.slice(
+            importDeclarationText.indexOf('{'),
+            importDeclarationText.indexOf('}') + 1,
+          )
           return fixer.replaceText(
             node.parent,
             [
               `${importStringPrefix} * as ${node.local.name} from ${importSourceQuoted}${semi}`,
               `${importStringPrefix} ${specifiers} from ${importSourceQuoted}${semi}`,
-            ].join("\n"),
-          );
+            ].join('\n'),
+          )
         },
-      });
+      })
     },
-  };
+  }
 }
 
-/**
- * Regular expression for matching a RegExp string.
- */
-const REGEXP_STR = /^\/(.+)\/([A-Za-z]*)$/u;
+/** Regular expression for matching a RegExp string. */
+const REGEXP_STR = /^\/(.+)\/([A-Za-z]*)$/u
 
 /**
- * Convert a string to the `RegExp`.
- * Normal strings (e.g. `"foo"`) is converted to `/^foo$/` of `RegExp`.
- * Strings like `"/^foo/i"` are converted to `/^foo/i` of `RegExp`.
- * @see https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/utils/regexp.ts
+ * Convert a string to the `RegExp`. Normal strings (e.g. `"foo"`) is converted
+ * to `/^foo$/` of `RegExp`. Strings like `"/^foo/i"` are converted to `/^foo/i`
+ * of `RegExp`.
+ *
  * @param string The string to convert.
  * @returns Returns the `RegExp`.
+ * @see https://github.com/sveltejs/eslint-plugin-svelte/blob/main/packages/eslint-plugin-svelte/src/utils/regexp.ts
  */
 function toRegExp(string: string): { test(s: string): boolean } {
-  const [, pattern, flags = "u"] = REGEXP_STR.exec(string) ?? [];
-  if (pattern != null) return new RegExp(pattern, flags);
-  return { test: (s) => s === string };
+  const [, pattern, flags = 'u'] = REGEXP_STR.exec(string) ?? []
+  if (pattern != null) return new RegExp(pattern, flags)
+  return { test: s => s === string }
 }
 
 /**
  * Checks whether given string is regexp string
+ *
  * @param string The string to check
- * @returns boolean
+ * @returns Boolean
  */
 // function isRegExp(string: string): boolean {
 //   return Boolean(REGEXP_STR.test(string));

--- a/test/rules/prefer-namespace-import.spec.ts
+++ b/test/rules/prefer-namespace-import.spec.ts
@@ -1,80 +1,55 @@
 import { RuleTester as TSESLintRuleTester } from '@typescript-eslint/rule-tester'
-import type { TSESLint } from '@typescript-eslint/utils'
 
-import {
-  createRuleTestCaseFunctions,
-  getNonDefaultParsers,
-  parsers,
-} from '../utils.js'
+import { createRuleTestCaseFunctions } from '../utils.js'
 
-import { cjsRequire as require } from 'eslint-plugin-import-x'
 import rule from 'eslint-plugin-import-x/rules/prefer-namespace-import'
 
 const ruleTester = new TSESLintRuleTester()
 
 const { tValid, tInvalid } = createRuleTestCaseFunctions<typeof rule>()
 
-describe('TypeScript', () => {
-  for (const parser of getNonDefaultParsers()) {
-    const parserConfig = {
-      languageOptions: {
-        ...(parser === parsers.BABEL && {
-          parser: require<TSESLint.Parser.LooseParserModule>(parsers.BABEL),
-        }),
-      },
-      settings: {
-        'import-x/parsers': { [parsers.TS]: ['.ts'] },
-        'import-x/resolver': { 'eslint-import-resolver-typescript': true },
-      },
-    }
-
-    ruleTester.run('prefer-namespace-import', rule, {
-      valid: [
-        tValid({
-          code: `
+ruleTester.run('prefer-namespace-import', rule, {
+  valid: [
+    tValid({
+      code: `
           import * as Name from '@scope/name';
           `,
-          ...parserConfig,
-        }),
-        tValid({
-          code: `
+    }),
+    tValid({
+      code: `
           import * as Name from 'prefix-name';
           `,
-          ...parserConfig,
-        }),
-        tValid({
-          code: `
+    }),
+    tValid({
+      code: `
           import * as Name1 from '@scope/name';
           import * as Name2 from 'prefix-name';
           `,
-          ...parserConfig,
-        }),
-      ],
-      invalid: [
-        tInvalid({
-          code: `
+    }),
+  ],
+  invalid: [
+    tInvalid({
+      code: `
           import Name1 from '@scope/name';
           import Name2 from 'prefix-name';`,
-          errors: [
-            {
-              messageId: 'preferNamespaceImport',
-              data: { source: '@scope/name', specifier: 'Name1' },
-            },
-            {
-              messageId: 'preferNamespaceImport',
-              data: { source: 'prefix-name', specifier: 'Name2' },
-            },
-          ],
-          options: [
-            {
-              patterns: ['/^@scope/', '/^prefix-/'],
-            },
-          ],
-          output: `
+      errors: [
+        {
+          messageId: 'preferNamespaceImport',
+          data: { source: '@scope/name', specifier: 'Name1' },
+        },
+        {
+          messageId: 'preferNamespaceImport',
+          data: { source: 'prefix-name', specifier: 'Name2' },
+        },
+      ],
+      options: [
+        {
+          patterns: ['/^@scope/', '/^prefix-/'],
+        },
+      ],
+      output: `
           import * as Name1 from '@scope/name';
           import * as Name2 from 'prefix-name';`,
-        }),
-      ],
-    })
-  }
+    }),
+  ],
 })

--- a/test/rules/prefer-namespace-import.spec.ts
+++ b/test/rules/prefer-namespace-import.spec.ts
@@ -1,12 +1,21 @@
 import { RuleTester as TSESLintRuleTester } from '@typescript-eslint/rule-tester'
+import type { TSESLint } from '@typescript-eslint/utils'
 
-import { createRuleTestCaseFunctions } from '../utils.js'
+import {
+  createRuleTestCaseFunctions,
+  getNonDefaultParsers,
+  parsers,
+  testFilePath,
+} from '../utils.js'
 
+import { cjsRequire as require } from 'eslint-plugin-import-x'
 import rule from 'eslint-plugin-import-x/rules/prefer-namespace-import'
 
 const ruleTester = new TSESLintRuleTester()
 
 const { tValid, tInvalid } = createRuleTestCaseFunctions<typeof rule>()
+
+const options = [{ patterns: ['/^@scope/', '/^prefix-/'] }] as const
 
 ruleTester.run('prefer-namespace-import', rule, {
   valid: [
@@ -24,11 +33,7 @@ ruleTester.run('prefer-namespace-import', rule, {
     }),
     tValid({
       code: `import Name from 'other-name';`,
-      options: [
-        {
-          patterns: ['/^@scope/', '/^prefix-/'],
-        },
-      ],
+      options,
     }),
   ],
   invalid: [
@@ -36,8 +41,9 @@ ruleTester.run('prefer-namespace-import', rule, {
       code: `
 import Name1 from '@scope/name';
 import Name2 from 'prefix-name';
-import Name3, { named } from 'prefix-name';
-import Name4 from 'other-name';
+import Name3 from 'prefix-name' with { type: 'json' };
+import Name4, { name4 } from 'prefix-name' with { type: 'json' };
+import Name5 from 'other-name';
           `,
       errors: [
         {
@@ -52,19 +58,89 @@ import Name4 from 'other-name';
           messageId: 'preferNamespaceImport',
           data: { source: 'prefix-name', specifier: 'Name3' },
         },
-      ],
-      options: [
         {
-          patterns: ['/^@scope/', '/^prefix-/'],
+          messageId: 'preferNamespaceImport',
+          data: { source: 'prefix-name', specifier: 'Name4' },
         },
       ],
+      options,
       output: `
 import * as Name1 from '@scope/name';
 import * as Name2 from 'prefix-name';
-import * as Name3 from 'prefix-name';
-import { named } from 'prefix-name';
-import Name4 from 'other-name';
+import * as Name3 from 'prefix-name' with { type: 'json' };
+import * as Name4 from 'prefix-name' with { type: 'json' };
+import { name4 } from 'prefix-name' with { type: 'json' };
+import Name5 from 'other-name';
           `,
     }),
   ],
+})
+
+describe('TypeScript', () => {
+  for (const parser of getNonDefaultParsers()) {
+    const parserConfig = {
+      languageOptions: {
+        ...(parser === parsers.BABEL && {
+          parser: require<TSESLint.Parser.LooseParserModule>(parsers.BABEL),
+        }),
+      },
+      filename: testFilePath('foo.ts'),
+    }
+
+    ruleTester.run('prefer-namespace-import', rule, {
+      valid: [
+        tValid({
+          code: `
+          import type * as Name1 from '@scope/name';
+          import type * as Name2 from 'prefix-name';
+          `,
+          ...parserConfig,
+        }),
+        tValid({
+          code: `import type Name from 'other-name';`,
+          options,
+          ...parserConfig,
+        }),
+      ],
+      invalid: [
+        tInvalid({
+          code: `
+import type Name1 from '@scope/name';
+import type Name2 from 'prefix-name';
+import type Name3 from 'prefix-name' with { type: 'json' };
+import Name4, { type name4 } from 'prefix-name' with { type: 'json' };
+import type Name5 from 'other-name';
+          `,
+          errors: [
+            {
+              messageId: 'preferNamespaceImport',
+              data: { source: '@scope/name', specifier: 'Name1' },
+            },
+            {
+              messageId: 'preferNamespaceImport',
+              data: { source: 'prefix-name', specifier: 'Name2' },
+            },
+            {
+              messageId: 'preferNamespaceImport',
+              data: { source: 'prefix-name', specifier: 'Name3' },
+            },
+            {
+              messageId: 'preferNamespaceImport',
+              data: { source: 'prefix-name', specifier: 'Name4' },
+            },
+          ],
+          options,
+          output: `
+import type * as Name1 from '@scope/name';
+import type * as Name2 from 'prefix-name';
+import type * as Name3 from 'prefix-name' with { type: 'json' };
+import * as Name4 from 'prefix-name' with { type: 'json' };
+import { type name4 } from 'prefix-name' with { type: 'json' };
+import type Name5 from 'other-name';
+          `,
+          ...parserConfig,
+        }),
+      ],
+    })
+  }
 })

--- a/test/rules/prefer-namespace-import.spec.ts
+++ b/test/rules/prefer-namespace-import.spec.ts
@@ -57,23 +57,23 @@ describe('TypeScript', () => {
           import Name2 from 'prefix-name';`,
           errors: [
             {
-              messageId: "preferNamespaceImport",
-              data: { source: "@scope/name", specifier: "Name1" },
+              messageId: 'preferNamespaceImport',
+              data: { source: '@scope/name', specifier: 'Name1' },
             },
             {
-              messageId: "preferNamespaceImport",
-              data: { source: "prefix-name", specifier: "Name2" },
+              messageId: 'preferNamespaceImport',
+              data: { source: 'prefix-name', specifier: 'Name2' },
             },
           ],
           options: [
             {
-              patterns: ["/^@scope/", "/^prefix-/"],
+              patterns: ['/^@scope/', '/^prefix-/'],
             },
           ],
           output: `
           import * as Name1 from '@scope/name';
           import * as Name2 from 'prefix-name';`,
-        })
+        }),
       ],
     })
   }

--- a/test/rules/prefer-namespace-import.spec.ts
+++ b/test/rules/prefer-namespace-import.spec.ts
@@ -15,7 +15,7 @@ const ruleTester = new TSESLintRuleTester()
 
 const { tValid, tInvalid } = createRuleTestCaseFunctions<typeof rule>()
 
-const options = [{ patterns: ['/^@scope/', '/^prefix-/'] }] as const
+const options = [{ patterns: ['/^@scope/', '/^prefix-/', 'specific'] }] as const
 
 ruleTester.run('prefer-namespace-import', rule, {
   valid: [
@@ -26,9 +26,13 @@ ruleTester.run('prefer-namespace-import', rule, {
       code: `import * as Name from 'prefix-name';`,
     }),
     tValid({
+      code: `import * as Name from 'specific';`,
+    }),
+    tValid({
       code: `
           import * as Name1 from '@scope/name';
           import * as Name2 from 'prefix-name';
+          import * as Name2 from 'specific';
           `,
     }),
     tValid({
@@ -43,7 +47,8 @@ import Name1 from '@scope/name';
 import Name2 from 'prefix-name';
 import Name3 from 'prefix-name' with { type: 'json' };
 import Name4, { name4 } from 'prefix-name' with { type: 'json' };
-import Name5 from 'other-name';
+import Name5 from 'specific';
+import Name6 from 'other-name';
           `,
       errors: [
         {
@@ -62,6 +67,10 @@ import Name5 from 'other-name';
           messageId: 'preferNamespaceImport',
           data: { source: 'prefix-name', specifier: 'Name4' },
         },
+        {
+          messageId: 'preferNamespaceImport',
+          data: { source: 'specific', specifier: 'Name5' },
+        },
       ],
       options,
       output: `
@@ -70,7 +79,8 @@ import * as Name2 from 'prefix-name';
 import * as Name3 from 'prefix-name' with { type: 'json' };
 import * as Name4 from 'prefix-name' with { type: 'json' };
 import { name4 } from 'prefix-name' with { type: 'json' };
-import Name5 from 'other-name';
+import * as Name5 from 'specific';
+import Name6 from 'other-name';
           `,
     }),
   ],
@@ -109,7 +119,8 @@ import type Name1 from '@scope/name';
 import type Name2 from 'prefix-name';
 import type Name3 from 'prefix-name' with { type: 'json' };
 import Name4, { type name4 } from 'prefix-name' with { type: 'json' };
-import type Name5 from 'other-name';
+import type Name5 from 'specific';
+import type Name6 from 'other-name';
           `,
           errors: [
             {
@@ -128,6 +139,10 @@ import type Name5 from 'other-name';
               messageId: 'preferNamespaceImport',
               data: { source: 'prefix-name', specifier: 'Name4' },
             },
+            {
+              messageId: 'preferNamespaceImport',
+              data: { source: 'specific', specifier: 'Name5' },
+            },
           ],
           options,
           output: `
@@ -136,7 +151,8 @@ import type * as Name2 from 'prefix-name';
 import type * as Name3 from 'prefix-name' with { type: 'json' };
 import * as Name4 from 'prefix-name' with { type: 'json' };
 import { type name4 } from 'prefix-name' with { type: 'json' };
-import type Name5 from 'other-name';
+import type * as Name5 from 'specific';
+import type Name6 from 'other-name';
           `,
           ...parserConfig,
         }),

--- a/test/rules/prefer-namespace-import.spec.ts
+++ b/test/rules/prefer-namespace-import.spec.ts
@@ -11,14 +11,10 @@ const { tValid, tInvalid } = createRuleTestCaseFunctions<typeof rule>()
 ruleTester.run('prefer-namespace-import', rule, {
   valid: [
     tValid({
-      code: `
-          import * as Name from '@scope/name';
-          `,
+      code: `import * as Name from '@scope/name';`,
     }),
     tValid({
-      code: `
-          import * as Name from 'prefix-name';
-          `,
+      code: `import * as Name from 'prefix-name';`,
     }),
     tValid({
       code: `
@@ -26,12 +22,23 @@ ruleTester.run('prefer-namespace-import', rule, {
           import * as Name2 from 'prefix-name';
           `,
     }),
+    tValid({
+      code: `import Name from 'other-name';`,
+      options: [
+        {
+          patterns: ['/^@scope/', '/^prefix-/'],
+        },
+      ],
+    }),
   ],
   invalid: [
     tInvalid({
       code: `
-          import Name1 from '@scope/name';
-          import Name2 from 'prefix-name';`,
+import Name1 from '@scope/name';
+import Name2 from 'prefix-name';
+import Name3, { named } from 'prefix-name';
+import Name4 from 'other-name';
+          `,
       errors: [
         {
           messageId: 'preferNamespaceImport',
@@ -41,6 +48,10 @@ ruleTester.run('prefer-namespace-import', rule, {
           messageId: 'preferNamespaceImport',
           data: { source: 'prefix-name', specifier: 'Name2' },
         },
+        {
+          messageId: 'preferNamespaceImport',
+          data: { source: 'prefix-name', specifier: 'Name3' },
+        },
       ],
       options: [
         {
@@ -48,8 +59,12 @@ ruleTester.run('prefer-namespace-import', rule, {
         },
       ],
       output: `
-          import * as Name1 from '@scope/name';
-          import * as Name2 from 'prefix-name';`,
+import * as Name1 from '@scope/name';
+import * as Name2 from 'prefix-name';
+import * as Name3 from 'prefix-name';
+import { named } from 'prefix-name';
+import Name4 from 'other-name';
+          `,
     }),
   ],
 })

--- a/test/rules/prefer-namespace-import.spec.ts
+++ b/test/rules/prefer-namespace-import.spec.ts
@@ -1,0 +1,80 @@
+import { RuleTester as TSESLintRuleTester } from '@typescript-eslint/rule-tester'
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import {
+  createRuleTestCaseFunctions,
+  getNonDefaultParsers,
+  parsers,
+} from '../utils.js'
+
+import { cjsRequire as require } from 'eslint-plugin-import-x'
+import rule from 'eslint-plugin-import-x/rules/prefer-namespace-import'
+
+const ruleTester = new TSESLintRuleTester()
+
+const { tValid, tInvalid } = createRuleTestCaseFunctions<typeof rule>()
+
+describe('TypeScript', () => {
+  for (const parser of getNonDefaultParsers()) {
+    const parserConfig = {
+      languageOptions: {
+        ...(parser === parsers.BABEL && {
+          parser: require<TSESLint.Parser.LooseParserModule>(parsers.BABEL),
+        }),
+      },
+      settings: {
+        'import-x/parsers': { [parsers.TS]: ['.ts'] },
+        'import-x/resolver': { 'eslint-import-resolver-typescript': true },
+      },
+    }
+
+    ruleTester.run('prefer-namespace-import', rule, {
+      valid: [
+        tValid({
+          code: `
+          import * as Name from '@scope/name';
+          `,
+          ...parserConfig,
+        }),
+        tValid({
+          code: `
+          import * as Name from 'prefix-name';
+          `,
+          ...parserConfig,
+        }),
+        tValid({
+          code: `
+          import * as Name1 from '@scope/name';
+          import * as Name2 from 'prefix-name';
+          `,
+          ...parserConfig,
+        }),
+      ],
+      invalid: [
+        tInvalid({
+          code: `
+          import Name1 from '@scope/name';
+          import Name2 from 'prefix-name';`,
+          errors: [
+            {
+              messageId: "preferNamespaceImport",
+              data: { source: "@scope/name", specifier: "Name1" },
+            },
+            {
+              messageId: "preferNamespaceImport",
+              data: { source: "prefix-name", specifier: "Name2" },
+            },
+          ],
+          options: [
+            {
+              patterns: ["/^@scope/", "/^prefix-/"],
+            },
+          ],
+          output: `
+          import * as Name1 from '@scope/name';
+          import * as Name2 from 'prefix-name';`,
+        })
+      ],
+    })
+  }
+})

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -56,14 +56,6 @@ function createRuleTestCase<TTestCase extends TSESLintValidTestCase<unknown[]>>(
   return {
     filename: TEST_FILENAME,
     ...t,
-    languageOptions: {
-      ...t.languageOptions,
-      parserOptions: {
-        sourceType: 'module',
-        ecmaVersion: 9,
-        ...t.languageOptions?.parserOptions,
-      },
-    },
   }
 }
 


### PR DESCRIPTION
close #258
related #385

https://eslint-react.xyz/docs/rules/prefer-react-namespace-import
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `prefer-namespace-import` rule to enforce namespace imports for specified modules, with documentation and tests.
> 
>   - **New Rule**:
>     - Added `prefer-namespace-import` rule in `src/rules/prefer-namespace-import.ts` to enforce namespace imports for specified modules.
>     - Rule is automatically fixable and configurable with patterns for module matching.
>   - **Documentation**:
>     - Added `docs/rules/prefer-namespace-import.md` with rule details and examples.
>     - Updated `README.md` to include the new rule in the rules list.
>   - **Tests**:
>     - Added tests for `prefer-namespace-import` in `test/rules/prefer-namespace-import.spec.ts` to verify rule enforcement and autofix behavior.
>   - **Configuration**:
>     - Updated `src/index.ts` to include the new rule in the plugin's ruleset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 6e30b35190c3003fe325605b493a738c1c407f4a. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new ESLint rule enforcing namespace imports for modules matching user-defined patterns.  
- **Documentation**
  - Added detailed documentation and usage examples for the new rule.  
  - Updated the README to include the new rule entry.  
- **Tests**
  - Added comprehensive tests verifying rule enforcement and autofix functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->