### PR TITLE
test: only run pnp case for `test-compiled`

### DIFF
--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -2,9 +2,11 @@ import path from 'node:path'
 
 import { exec } from 'tinyexec'
 
+import { testCompiled } from './utils.js'
+
 const TIMEOUT = 60_000
 
-describe('yarn pnp', () => {
+;(testCompiled ? describe : describe.skip)('yarn pnp', () => {
   const yarnPnpDir = path.resolve('test/fixtures/yarn-pnp')
   const execOptions = { nodeOptions: { cwd: yarnPnpDir } }
 


### PR DESCRIPTION
close #249

prepare for #384

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally run `yarn pnp` tests in `test/fixtures.spec.ts` based on `testCompiled` flag.
> 
>   - **Tests**:
>     - Conditionally run `yarn pnp` test suite in `test/fixtures.spec.ts` based on `testCompiled` flag.
>     - Uses `describe.skip` to skip tests if `testCompiled` is false.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 26c66e8b3dfdb2b50ad3b9ecf333dd4cee75d96b. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Test execution is now dynamically controlled, allowing certain tests to be skipped based on runtime conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->