### PR TITLE
fix(extensions): always calculate `fix` option

### DIFF
--- a/.changeset/angry-lions-learn.md
+++ b/.changeset/angry-lions-learn.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix(extensions): always calculate `fix` option

--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -4,6 +4,18 @@
 
 <!-- end auto-generated rule header -->
 
+> [!NOTE]
+>
+> This rule is only fixable when the `fix` option is set to `true` for compatibility, otherwise `suggestions` will be provided instead.
+>
+> Example:
+>
+> ```json
+> "import-x/extensions": ["error", "never", { "fix": true }]
+> ```
+>
+> It will change to be automatically fixable in the next major version.
+
 Some file resolve algorithms allow you to omit the file extension within the import source path. For example the `node` resolver (which does not yet support ESM/`import`) can resolve `./foo/bar` to the absolute path `/User/someone/foo/bar.js` because the `.js` extension is resolved automatically by default in CJS. Depending on the resolver you can configure more extensions to get resolved automatically.
 
 In order to provide a consistent use of file extensions across your code base, this rule can enforce or disallow the use of certain file extensions.

--- a/src/rules/extensions.ts
+++ b/src/rules/extensions.ts
@@ -132,6 +132,10 @@ function buildProperties(context: RuleContext<MessageId, Options>) {
       continue
     }
 
+    if (obj.fix != null) {
+      result.fix = Boolean(obj.fix)
+    }
+
     // If this is not the new structure, transfer all props to result.pattern
     if (
       (!('pattern' in obj) || obj.pattern == null) &&
@@ -154,10 +158,6 @@ function buildProperties(context: RuleContext<MessageId, Options>) {
 
     if (typeof obj.checkTypeImports === 'boolean') {
       result.checkTypeImports = obj.checkTypeImports
-    }
-
-    if (obj.fix != null) {
-      result.fix = Boolean(obj.fix)
     }
 
     if (Array.isArray(obj.pathGroupOverrides)) {

--- a/test/rules/extensions.spec.ts
+++ b/test/rules/extensions.spec.ts
@@ -174,6 +174,73 @@ ruleTester.run('extensions', rule, {
 
   invalid: [
     tInvalid({
+      name: 'extensions should autofix by default',
+      code: 'import a from "a/foo.js"',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpected',
+          data: { extension: 'js', importPath: 'a/foo.js' },
+          line: 1,
+          column: 15,
+        },
+      ],
+      output: 'import a from "a/foo"',
+    }),
+    tInvalid({
+      name: 'extensions should autofix when fix is set to true',
+      code: 'import a from "a/foo.js"',
+      options: ['never', {fix: true}],
+      errors: [
+        {
+          messageId: 'unexpected',
+          data: { extension: 'js', importPath: 'a/foo.js' },
+          line: 1,
+          column: 15,
+        },
+      ],
+      output: 'import a from "a/foo"',
+    }),
+    tInvalid({
+      name: 'extensions should autofix when fix is set to true and a pattern object is provided',
+      code: 'import a from "a/foo.js"',
+      options: ['never', {fix: true, pattern: {}}],
+      errors: [
+        {
+          messageId: 'unexpected',
+          data: { extension: 'js', importPath: 'a/foo.js' },
+          line: 1,
+          column: 15,
+        },
+      ],
+      output: 'import a from "a/foo"',
+    }),
+    tInvalid({
+      name: 'extensions should not autofix when fix is set to false',
+      code: 'import a from "a/foo.js"',
+      options: ['never', {fix: false}],
+      errors: [
+        {
+          messageId: 'unexpected',
+          data: { extension: 'js', importPath: 'a/foo.js' },
+          line: 1,
+          column: 15,
+          suggestions: [
+            {
+              messageId: 'removeUnexpected',
+              data: {
+                extension: 'js',
+                importPath: 'a/foo.js',
+                fixedImportPath: 'a/foo',
+              },
+              output: 'import a from "a/foo"',
+            },
+          ],
+        },
+      ],
+      output: null,
+    }),
+    tInvalid({
       code: 'import a from "a/index.js"',
       errors: [
         {

--- a/test/rules/extensions.spec.ts
+++ b/test/rules/extensions.spec.ts
@@ -174,7 +174,7 @@ ruleTester.run('extensions', rule, {
 
   invalid: [
     tInvalid({
-      name: 'extensions should autofix by default',
+      name: 'extensions should provide suggestions by default',
       code: 'import a from "./foo.js"',
       options: ['never'],
       errors: [
@@ -183,14 +183,24 @@ ruleTester.run('extensions', rule, {
           data: { extension: 'js', importPath: './foo.js' },
           line: 1,
           column: 15,
+          suggestions: [
+            {
+              messageId: 'removeUnexpected',
+              data: {
+                extension: 'js',
+                importPath: './foo.js',
+                fixedImportPath: './foo',
+              },
+              output: 'import a from "./foo"',
+            },
+          ],
         },
       ],
-      output: 'import a from "./foo"',
     }),
     tInvalid({
       name: 'extensions should autofix when fix is set to true',
       code: 'import a from "./foo.js"',
-      options: ['never', {fix: true}],
+      options: ['never', { fix: true }],
       errors: [
         {
           messageId: 'unexpected',
@@ -204,7 +214,7 @@ ruleTester.run('extensions', rule, {
     tInvalid({
       name: 'extensions should autofix when fix is set to true and a pattern object is provided',
       code: 'import a from "./foo.js"',
-      options: ['never', {fix: true, pattern: {}}],
+      options: ['never', { fix: true, pattern: {} }],
       errors: [
         {
           messageId: 'unexpected',
@@ -218,7 +228,7 @@ ruleTester.run('extensions', rule, {
     tInvalid({
       name: 'extensions should not autofix when fix is set to false',
       code: 'import a from "./foo.js"',
-      options: ['never', {fix: false}],
+      options: ['never', { fix: false }],
       errors: [
         {
           messageId: 'unexpected',

--- a/test/rules/extensions.spec.ts
+++ b/test/rules/extensions.spec.ts
@@ -175,54 +175,54 @@ ruleTester.run('extensions', rule, {
   invalid: [
     tInvalid({
       name: 'extensions should autofix by default',
-      code: 'import a from "a/foo.js"',
+      code: 'import a from "./foo.js"',
       options: ['never'],
       errors: [
         {
           messageId: 'unexpected',
-          data: { extension: 'js', importPath: 'a/foo.js' },
+          data: { extension: 'js', importPath: './foo.js' },
           line: 1,
           column: 15,
         },
       ],
-      output: 'import a from "a/foo"',
+      output: 'import a from "./foo"',
     }),
     tInvalid({
       name: 'extensions should autofix when fix is set to true',
-      code: 'import a from "a/foo.js"',
+      code: 'import a from "./foo.js"',
       options: ['never', {fix: true}],
       errors: [
         {
           messageId: 'unexpected',
-          data: { extension: 'js', importPath: 'a/foo.js' },
+          data: { extension: 'js', importPath: './foo.js' },
           line: 1,
           column: 15,
         },
       ],
-      output: 'import a from "a/foo"',
+      output: 'import a from "./foo"',
     }),
     tInvalid({
       name: 'extensions should autofix when fix is set to true and a pattern object is provided',
-      code: 'import a from "a/foo.js"',
+      code: 'import a from "./foo.js"',
       options: ['never', {fix: true, pattern: {}}],
       errors: [
         {
           messageId: 'unexpected',
-          data: { extension: 'js', importPath: 'a/foo.js' },
+          data: { extension: 'js', importPath: './foo.js' },
           line: 1,
           column: 15,
         },
       ],
-      output: 'import a from "a/foo"',
+      output: 'import a from "./foo"',
     }),
     tInvalid({
       name: 'extensions should not autofix when fix is set to false',
-      code: 'import a from "a/foo.js"',
+      code: 'import a from "./foo.js"',
       options: ['never', {fix: false}],
       errors: [
         {
           messageId: 'unexpected',
-          data: { extension: 'js', importPath: 'a/foo.js' },
+          data: { extension: 'js', importPath: './foo.js' },
           line: 1,
           column: 15,
           suggestions: [
@@ -230,10 +230,10 @@ ruleTester.run('extensions', rule, {
               messageId: 'removeUnexpected',
               data: {
                 extension: 'js',
-                importPath: 'a/foo.js',
-                fixedImportPath: 'a/foo',
+                importPath: './foo.js',
+                fixedImportPath: './foo',
               },
-              output: 'import a from "a/foo"',
+              output: 'import a from "./foo"',
             },
           ],
         },


### PR DESCRIPTION
close #391

Initially, it only adds failing test cases that expose the broken autofix behavior of the `extensions` rule.

### Root issue

Autofix does not work unless both `fix: true` and a `pattern` object are set — even if the pattern is empty. This behavior is not intuitive, not documented, and not consistent with how autofix works in other ESLint rules.

### Suggested solution

The rule should apply autofixes by default when it is safe to do so. The `fix` option should be removed entirely.

This PR starts by adding tests to document the current (broken) behavior.

### Notes

- There are around 80 tests in `extensions.spec.ts`, but none of the existing tests asserted on the actual `output` field, which is what validates whether autofixes are being applied. That gap likely contributed to this issue being missed.
- The new tests are intentionally simple and direct, and I haven't attempted to deduplicate or reorganize them within the file. The test suite is already quite dense, and my focus was on surfacing the issue as clearly as possible.
- This PR is open to edits by maintainers. If you'd like to continue from here and iterate toward a fix, feel free to push directly.
- For an easier-to-follow standalone reproduction, see:  https://github.com/lnhrdt/un-ts-eslint-plugin-import-x-issue-391
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add failing tests in `extensions.spec.ts` to expose broken autofix behavior of `extensions` rule requiring both `fix: true` and a `pattern` object.
> 
>   - **Tests**:
>     - Add failing test cases in `extensions.spec.ts` to expose broken autofix behavior of `extensions` rule.
>     - Tests show autofix requires both `fix: true` and a `pattern` object, even if empty, to work.
>     - Tests include cases for default autofix, `fix: true`, `fix: true` with pattern, and `fix: false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for d51f400ce566c40fba65d332a80cf0b21b16158b. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new test cases to verify autofix and suggestion behaviors for import path file extensions under different autofix settings.  
- **Bug Fixes**
  - Ensured consistent handling of the autofix option for import path extensions.  
- **Documentation**
  - Clarified that automatic fixing of import extensions requires explicit enabling of the fix option, with examples and future default behavior noted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->