### PR TITLE
fix(extensions): should only report on fixable paths

### DIFF
--- a/.changeset/dull-wombats-boil.md
+++ b/.changeset/dull-wombats-boil.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix(extensions): should only report on fixable paths

--- a/test/rules/extensions.spec.ts
+++ b/test/rules/extensions.spec.ts
@@ -170,6 +170,11 @@ ruleTester.run('extensions', rule, {
       code: "import foo from './foo.js';",
       options: [{ fix: true, pattern: { js: 'always' } }],
     }),
+
+    tValid({
+      code: "import eslint from 'eslint';",
+      options: [{ fix: true, pattern: { js: 'always' } }],
+    }),
   ],
 
   invalid: [


### PR DESCRIPTION
close #394
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure only fixable paths are reported in `extensions.ts` by adding checks and updating tests accordingly.
> 
>   - **Behavior**:
>     - In `extensions.ts`, added checks to ensure only fixable paths are reported by comparing `importPath` with `fixedImportPath` and `resolvedPath` with `resolve(pathname, context)`.
>     - If paths are not fixable, the function returns early, preventing unnecessary reports.
>   - **Tests**:
>     - Added valid test case in `extensions.spec.ts` for `import eslint from 'eslint';` with `fix: true` and `pattern: { js: 'always' }`.
>     - Ensured tests cover scenarios where paths are not fixable and should not be reported.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 5d7ddfcb7a43c3d62a09009e667b587c1144bf94. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of import path extensions to ensure only fixable paths are reported, preventing unnecessary or incorrect fixes.

- **Tests**
  - Added a new test case to confirm that importing packages without a file extension is valid under specific rule options.

- **Chores**
  - Updated documentation to reflect the patch addressing extension handling in import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->