### PR TITLE
fix(package): remove config and rules exports pointing to empty files

### DIFF
--- a/.changeset/swift-friends-remain.md
+++ b/.changeset/swift-friends-remain.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix(package): remove config and rules exports pointing to empty files

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
         "default": "./lib/index.cjs"
       }
     },
-    "./config": "./lib/config/index.js",
-    "./rules": "./lib/rules/index.js",
     "./utils": "./lib/utils/index.js",
     "./package.json": "./package.json",
     "./*": "./lib/*.js"


### PR DESCRIPTION
- closes #405
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `config` and `rules` exports from `package.json` as they pointed to empty files.
> 
>   - **Exports Removal**:
>     - Removed `./config` and `./rules` exports from `package.json` as they pointed to empty files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for dd7103d4746c06dfceedb3ad2282e16f3e22c352. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up package exports by removing unused configuration and rules exports, streamlining the available export paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->