### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/src/rules/dynamic-import-chunkname.ts
+++ b/src/rules/dynamic-import-chunkname.ts
@@ -48,6 +48,7 @@ export default createRule<[Options?], MessageId>({
             type: 'string',
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {

--- a/src/rules/extensions.ts
+++ b/src/rules/extensions.ts
@@ -60,6 +60,7 @@ const properties = {
       type: 'boolean',
     },
   },
+  additionalProperties: false,
 } satisfies JSONSchema.JSONSchema4
 
 export type Modifier = (typeof modifierValues)[number]

--- a/src/rules/no-namespace.ts
+++ b/src/rules/no-namespace.ts
@@ -32,6 +32,7 @@ export default createRule<[Options?], MessageId>({
             uniqueItems: true,
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {

--- a/src/rules/no-unused-modules.ts
+++ b/src/rules/no-unused-modules.ts
@@ -6,7 +6,7 @@
 import path from 'node:path'
 
 import { TSESTree } from '@typescript-eslint/types'
-import type { TSESLint } from '@typescript-eslint/utils'
+import type { JSONSchema, TSESLint } from '@typescript-eslint/utils'
 // eslint-disable-next-line import-x/default -- incorrect types , commonjs actually
 import eslintUnsupportedApi from 'eslint/use-at-your-own-risk'
 import type * as ESLint9UnsupportedApi from 'eslint9/use-at-your-own-risk'
@@ -470,7 +470,7 @@ const fileIsInPkg = (file: string) => {
 export interface Options {
   src?: string[]
   ignoreExports?: string[]
-  missingExports?: true
+  missingExports?: boolean
   unusedExports?: boolean
   ignoreUnusedTypeExports?: boolean
   suppressMissingFileEnumeratorAPIWarning?: boolean
@@ -479,6 +479,45 @@ export interface Options {
 type MessageId = 'notFound' | 'unused'
 
 let eslint10WarningEmitted = false
+
+const SHARED_OPTIONS_SCHEMA_PROPERTIES = {
+  src: {
+    description: 'files/paths to be analyzed (only for unused exports)',
+    type: 'array',
+    uniqueItems: true,
+    items: {
+      type: 'string',
+      minLength: 1,
+    },
+  },
+  ignoreExports: {
+    description:
+      'files/paths for which unused exports will not be reported (e.g module entry points)',
+    type: 'array',
+    uniqueItems: true,
+    items: {
+      type: 'string',
+      minLength: 1,
+    },
+  },
+  missingExports: {
+    description: 'report modules without any exports',
+    type: 'boolean',
+  },
+  unusedExports: {
+    description: 'report exports without any usage',
+    type: 'boolean',
+  },
+  ignoreUnusedTypeExports: {
+    description: 'ignore type exports without any usage',
+    type: 'boolean',
+  },
+  suppressMissingFileEnumeratorAPIWarning: {
+    description:
+      'ESLint 10 and later versions remove the FileEnumerator API, which is required by the "no-unused-modules" rule. Therefore a warning message will be logged before an alternative is implemented. You can suppress the warning with this option',
+    type: 'boolean',
+  },
+} satisfies JSONSchema.JSONSchema4ObjectSchema['properties']
 
 export default createRule<Options[], MessageId>({
   name: 'no-unused-modules',
@@ -491,52 +530,15 @@ export default createRule<Options[], MessageId>({
     },
     schema: [
       {
-        type: 'object',
-        properties: {
-          src: {
-            description: 'files/paths to be analyzed (only for unused exports)',
-            type: 'array',
-            uniqueItems: true,
-            items: {
-              type: 'string',
-              minLength: 1,
-            },
-          },
-          ignoreExports: {
-            description:
-              'files/paths for which unused exports will not be reported (e.g module entry points)',
-            type: 'array',
-            uniqueItems: true,
-            items: {
-              type: 'string',
-              minLength: 1,
-            },
-          },
-          missingExports: {
-            description: 'report modules without any exports',
-            type: 'boolean',
-          },
-          unusedExports: {
-            description: 'report exports without any usage',
-            type: 'boolean',
-          },
-          ignoreUnusedTypeExports: {
-            description: 'ignore type exports without any usage',
-            type: 'boolean',
-          },
-          suppressMissingFileEnumeratorAPIWarning: {
-            description:
-              'ESLint 10 and later versions remove the FileEnumerator API, which is required by the "no-unused-modules" rule. Therefore a warning message will be logged before an alternative is implemented. You can suppress the warning with this option',
-            type: 'boolean',
-          },
-        },
         anyOf: [
           {
             type: 'object',
             properties: {
+              ...SHARED_OPTIONS_SCHEMA_PROPERTIES,
               unusedExports: {
+                description:
+                  SHARED_OPTIONS_SCHEMA_PROPERTIES.unusedExports.description,
                 type: 'boolean',
-                enum: [true],
               },
               src: {
                 type: 'array',
@@ -544,16 +546,20 @@ export default createRule<Options[], MessageId>({
               },
             },
             required: ['unusedExports'],
+            additionalProperties: false,
           },
           {
             type: 'object',
             properties: {
+              ...SHARED_OPTIONS_SCHEMA_PROPERTIES,
               missingExports: {
+                description:
+                  SHARED_OPTIONS_SCHEMA_PROPERTIES.missingExports.description,
                 type: 'boolean',
-                enum: [true],
               },
             },
             required: ['missingExports'],
+            additionalProperties: false,
           },
         ],
       },

--- a/src/rules/no-unused-modules.ts
+++ b/src/rules/no-unused-modules.ts
@@ -535,13 +535,8 @@ export default createRule<Options[], MessageId>({
             type: 'object',
             properties: {
               ...SHARED_OPTIONS_SCHEMA_PROPERTIES,
-              unusedExports: {
-                description:
-                  SHARED_OPTIONS_SCHEMA_PROPERTIES.unusedExports.description,
-                type: 'boolean',
-              },
               src: {
-                type: 'array',
+                ...SHARED_OPTIONS_SCHEMA_PROPERTIES.src,
                 minItems: 1,
               },
             },
@@ -550,14 +545,7 @@ export default createRule<Options[], MessageId>({
           },
           {
             type: 'object',
-            properties: {
-              ...SHARED_OPTIONS_SCHEMA_PROPERTIES,
-              missingExports: {
-                description:
-                  SHARED_OPTIONS_SCHEMA_PROPERTIES.missingExports.description,
-                type: 'boolean',
-              },
-            },
+            properties: SHARED_OPTIONS_SCHEMA_PROPERTIES,
             required: ['missingExports'],
             additionalProperties: false,
           },

--- a/src/utils/module-visitor.ts
+++ b/src/utils/module-visitor.ts
@@ -203,6 +203,7 @@ export function makeOptionsSchema(
       ignore: {
         type: 'array',
         minItems: 1,
+        items: { type: ['string', 'object'] }, // `object` is for `RegExp`s
         uniqueItems: true,
       },
     },


### PR DESCRIPTION
Some rules, for example [`dynamic-import-chunkname`](https://github.com/un-ts/eslint-plugin-import-x/blob/d0a78167791f41804e880356c9c69d7a45c4b45d/src/rules/dynamic-import-chunkname.ts#L34) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disallow extra properties in rule options for `dynamic-import-chunkname`, `extensions`, `no-namespace`, and `no-unused-modules` by setting `additionalProperties: false` in their schemas.
> 
>   - **Behavior**:
>     - Disallow extra properties in rule options by setting `additionalProperties: false` in the schema.
>     - Affects `dynamic-import-chunkname`, `extensions`, `no-namespace`, and `no-unused-modules` rules.
>   - **Schema Changes**:
>     - `dynamic-import-chunkname.ts`: Added `additionalProperties: false` to the options schema.
>     - `extensions.ts`: Added `additionalProperties: false` to the `properties` schema.
>     - `no-namespace.ts`: Added `additionalProperties: false` to the options schema.
>     - `no-unused-modules.ts`: Added `additionalProperties: false` to the options schema in two places.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for 51af82fe2a05001c2759aec8746b27a61a2e7987. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated the `no-unused-modules` rule’s options schema into shared, reusable definitions for clearer and more consistent validation.

* **New Features**
  * Strengthened configuration validation across multiple rules by disallowing unrecognized option properties.
  * Expanded support for `ignore` entries to be either strings or objects (e.g., RegExp-based inputs).
  * Updated `no-unused-modules` options validation so `missingExports` is treated as a boolean.

* **Chores**
  * Adjusted the `no-unused-modules` `missingExports` option type to match the validated schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->