### PR TITLE
fix(deps): replace `type-fest` w/ `@package-json/types`

### DIFF
--- a/.changeset/fix-type-fest-dependency.md
+++ b/.changeset/fix-type-fest-dependency.md
@@ -2,6 +2,6 @@
 "eslint-plugin-import-x": patch
 ---
 
-fix(deps): move type-fest from devDependencies to dependencies
+fix(deps): replace type-fest with @package-json/types
 
-Type-fest types are imported in published declaration files (eslint-import-context/lib/types.d.ts and lib/rules/no-extraneous-dependencies.d.ts), which causes TypeScript compilation errors for consumers who don't have skipLibCheck enabled. Moving type-fest to dependencies ensures the types are available to all consumers.
+PackageJson types are imported in published declaration files (lib/rules/no-extraneous-dependencies.d.ts and lib/utils/read-pkg-up.d.ts), which causes TypeScript compilation errors for consumers who don't have skipLibCheck enabled. Replacing type-fest with the smaller @package-json/types package ensures the types are available to all consumers while reducing bundle size.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     }
   },
   "dependencies": {
+    "@package-json/types": "^0.0.12",
     "@typescript-eslint/types": "^8.35.0",
     "comment-parser": "^1.4.1",
     "debug": "^4.4.1",
@@ -83,7 +84,6 @@
     "minimatch": "^9.0.3 || ^10.0.1",
     "semver": "^7.7.2",
     "stable-hash-x": "^0.2.0",
-    "type-fest": "^4.41.0",
     "unrs-resolver": "^1.9.2"
   },
   "devDependencies": {

--- a/src/rules/no-duplicates.ts
+++ b/src/rules/no-duplicates.ts
@@ -1,6 +1,6 @@
+import type { PackageJson } from '@package-json/types'
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import * as semver from 'semver'
-import type { PackageJson } from 'type-fest'
 
 import { cjsRequire } from '../require.js'
 import type { RuleContext } from '../types.js'

--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import type { PackageJson } from '@package-json/types'
 import type { TSESTree } from '@typescript-eslint/utils'
 import { minimatch } from 'minimatch'
-import type { PackageJson } from 'type-fest'
 
 import type { RuleContext } from '../types.js'
 import {

--- a/src/utils/read-pkg-up.ts
+++ b/src/utils/read-pkg-up.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 
-import type { PackageJson } from 'type-fest'
+import type { PackageJson } from '@package-json/types'
 
 import { pkgUp } from './pkg-up.js'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3140,6 +3140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@package-json/types@npm:^0.0.12":
+  version: 0.0.12
+  resolution: "@package-json/types@npm:0.0.12"
+  checksum: 10c0/d9bba086efe7b9901f02f1cff7a68ab23269aeddfb7ee92a16930e219f705bfc188b9fec2dd47265033dbda45ed1514d8a46f46363f38f1ad56bc993754126da
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -5951,6 +5958,7 @@ __metadata:
     "@commitlint/cli": "npm:^19.8.1"
     "@eslint/import-test-order-redirect-scoped": "link:./test/fixtures/order-redirect-scoped"
     "@eslint/js": "npm:^9.29.0"
+    "@package-json/types": "npm:^0.0.12"
     "@swc-node/jest": "npm:^1.8.13"
     "@swc/core": "npm:^1.12.7"
     "@swc/helpers": "npm:^0.5.17"
@@ -6012,7 +6020,6 @@ __metadata:
     tmp: "npm:^0.2.3"
     ts-node: "npm:^10.9.2"
     tsdown: "npm:^0.12.9"
-    type-fest: "npm:^4.41.0"
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.35.0"
     unrs-resolver: "npm:^1.9.2"
@@ -12525,7 +12532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.0.0, type-fest@npm:^4.18.2, type-fest@npm:^4.41.0":
+"type-fest@npm:^4.0.0, type-fest@npm:^4.18.2":
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
   checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4


### PR DESCRIPTION
`PackageJson` types are imported in published declaration files, which causes TypeScript compilation errors for consumers who don't have `skipLibCheck` enabled.

```
$ tsc

node_modules/eslint-plugin-import-x/lib/rules/no-extraneous-dependencies.d.ts:1:34 - error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.

1 import type { PackageJson } from 'type-fest';
                                   ~~~~~~~~~~~

node_modules/eslint-plugin-import-x/lib/utils/read-pkg-up.d.ts:1:34 - error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.

1 import type { PackageJson } from 'type-fest';
```

This PR replaces `type-fest` with the smaller `@package-json/types` package, ensuring the types are available to all consumers while reducing bundle size.

## Changes

- Replace `type-fest` with `@package-json/types` in dependencies
- Update all source file imports to use `@package-json/types`
- Remove `type-fest` dependency entirely (test imports are just strings, not actual code)