### PR TITLE
chore(deps): migrate from unrs-resolver to oxc-resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - 18
           - 20
           - 22
-          - 24
+          - 24.14 # https://github.com/nodejs/node/issues/62012
         eslint:
           - 8.56
           - 8
@@ -30,11 +30,11 @@ jobs:
 
         include:
           - executeLint: true
-            node: lts/*
+            node: 24.14
             eslint: 9
             os: ubuntu-latest
           - legacyNodeResolver: true
-            node: lts/*
+            node: 24.14
             eslint: 9
             os: ubuntu-latest
         exclude:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ So what are the differences from `eslint-plugin-import` exactly?
 - we target [Node `^18.18.0 || ^20.9.0 || >=21.1.0`](https://github.com/un-ts/eslint-plugin-import-x/blob/8b2d6d3b612eb57fb68c3fddec25b02fc622df7c/package.json#L12) + [ESLint `^8.57.0 || ^9.0.0`](https://github.com/un-ts/eslint-plugin-import-x/blob/8b2d6d3b612eb57fb68c3fddec25b02fc622df7c/package.json#L71), while `eslint-plugin-import` targets [Node `>=4`](https://github.com/import-js/eslint-plugin-import/blob/da5f6ec13160cb288338db0c2a00c34b2d932f0d/package.json#L6) and [ESLint `^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9`](https://github.com/import-js/eslint-plugin-import/blob/da5f6ec13160cb288338db0c2a00c34b2d932f0d/package.json#L115C16-L115C64)
 - we don't depend on old and outdated dependencies, so [we have 16 dependencies](https://npmgraph.js.org/?q=eslint-plugin-import-x) compared to [117 dependencies for `eslint-plugin-import`](https://npmgraph.js.org/?q=eslint-plugin-import)
 - `eslint-plugin-import` uses `tsconfig-paths` + `typescript` itself to load `tsconfig`s while we use the single `get-tsconfig` instead, which is much faster and cleaner
-- `eslint-plugin-import` uses [`resolve`] which doesn't support the `exports` field in `package.json` while we build our own rust-based resolver [`unrs-resolver`] instead, which is feature-rich and way more performant.
+- `eslint-plugin-import` uses [`resolve`] which doesn't support the `exports` field in `package.json` while we use the rust-based resolver [`oxc-resolver`] instead, which is feature-rich and way more performant.
 - Our [v3 resolver](./resolvers/README.md#v3) interface shares a single `resolver` instance by default which is used all across resolving chains so it would benefit from caching and memoization out-of-the-box
 - ...
 
@@ -682,7 +682,7 @@ Detailed changes for each release are documented in [CHANGELOG.md](./CHANGELOG.m
 [`get-tsconfig`]: https://github.com/privatenumber/get-tsconfig
 [`tsconfig-paths`]: https://github.com/dividab/tsconfig-paths
 [`typescript`]: https://github.com/microsoft/TypeScript
-[`unrs-resolver`]: https://github.com/unrs/unrs-resolver
+[`oxc-resolver`]: https://github.com/oxc-project/oxc-resolver
 [`resolve`]: https://www.npmjs.com/package/resolve
 [`externals`]: https://webpack.github.io/docs/library-and-externals.html
 [1stG.me]: https://www.1stG.me

--- a/package.json
+++ b/package.json
@@ -79,12 +79,12 @@
     "@typescript-eslint/types": "^8.56.0",
     "comment-parser": "^1.4.1",
     "debug": "^4.4.1",
-    "eslint-import-context": "^0.1.9",
+    "eslint-import-context": "^0.2.0",
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.3 || ^10.1.2",
+    "oxc-resolver": "^11.19.1",
     "semver": "^7.7.2",
-    "stable-hash-x": "^0.2.0",
-    "unrs-resolver": "^1.9.2"
+    "stable-hash-x": "^0.2.0"
   },
   "devDependencies": {
     "@1stg/commitlint-config": "^5.1.0",

--- a/resolvers/README.md
+++ b/resolvers/README.md
@@ -104,14 +104,14 @@ the resolver name used in logs/debug output
 
 ### Example
 
-Here is most of the [New Node resolver] at the time of this writing. It is just a wrapper around [`unrs-resolver`][unrs-resolver]:
+Here is most of the [New Node resolver] at the time of this writing. It is just a wrapper around [`oxc-resolver`][oxc-resolver]:
 
 ```js
 import module from 'node:module'
 import path from 'node:path'
 
-import { ResolverFactory } from 'unrs-resolver'
-import type { NapiResolveOptions } from 'unrs-resolver'
+import { ResolverFactory } from 'oxc-resolver'
+import type { NapiResolveOptions } from 'oxc-resolver'
 
 import type { NewResolver } from './types.js'
 
@@ -253,5 +253,5 @@ If the resolver cannot resolve `source` relative to `file`, it should just retur
 [eslint-import-context]: https://github.com/un-ts/eslint-import-context
 [eslint-plugin-import]: https://github.com/import-js/eslint-plugin-import
 [eslint-plugin-import-x]: https://github.com/un-ts/eslint-plugin-import-x
+[oxc-resolver]: https://github.com/oxc-project/oxc-resolver
 [resolve]: https://github.com/browserify/resolve
-[unrs-resolver]: https://github.com/unrs/unrs-resolver

--- a/src/node-resolver.ts
+++ b/src/node-resolver.ts
@@ -1,8 +1,8 @@
 import { isBuiltin } from 'node:module'
 import path from 'node:path'
 
-import { ResolverFactory } from 'unrs-resolver'
-import type { NapiResolveOptions } from 'unrs-resolver'
+import { ResolverFactory } from 'oxc-resolver'
+import type { NapiResolveOptions } from 'oxc-resolver'
 
 import type { NewResolver } from './types.js'
 

--- a/test/rules/no-duplicates.spec.ts
+++ b/test/rules/no-duplicates.spec.ts
@@ -87,8 +87,8 @@ ruleTester.run('no-duplicates', rule, {
 
     // ensure resolved path results in warnings
     tInvalid({
-      code: "import { x } from './bar'; import { y } from 'bar';",
-      output: "import { x, y  } from './bar'; ",
+      code: "import { x } from './bar/'; import { y } from 'bar';",
+      output: "import { x, y  } from './bar/'; ",
       settings: {
         'import-x/resolve': {
           paths: [path.resolve('test/fixtures')],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2818,6 +2818,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
+  languageName: node
+  linkType: hard
+
 "@nicolo-ribaudo/eslint-scope-5-internals@npm:5.1.1-v1":
   version: 5.1.1-v1
   resolution: "@nicolo-ribaudo/eslint-scope-5-internals@npm:5.1.1-v1"
@@ -3131,10 +3143,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-resolver/binding-android-arm-eabi@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.19.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-android-arm64@npm:11.19.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.19.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@oxc-resolver/binding-darwin-arm64@npm:5.3.0":
   version: 5.3.0
   resolution: "@oxc-resolver/binding-darwin-arm64@npm:5.3.0"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-x64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.19.1"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3145,10 +3185,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-resolver/binding-freebsd-x64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.19.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@oxc-resolver/binding-freebsd-x64@npm:5.3.0":
   version: 5.3.0
   resolution: "@oxc-resolver/binding-freebsd-x64@npm:5.3.0"
   conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.19.1"
+  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -3159,10 +3213,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.19.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@oxc-resolver/binding-linux-arm64-gnu@npm:5.3.0":
   version: 5.3.0
   resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:5.3.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3173,10 +3248,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@oxc-resolver/binding-linux-riscv64-gnu@npm:5.3.0":
   version: 5.3.0
   resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:5.3.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-s390x-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
@@ -3187,6 +3290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-resolver/binding-linux-x64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@oxc-resolver/binding-linux-x64-gnu@npm:5.3.0":
   version: 5.3.0
   resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:5.3.0"
@@ -3194,10 +3304,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-resolver/binding-linux-x64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@oxc-resolver/binding-linux-x64-musl@npm:5.3.0":
   version: 5.3.0
   resolution: "@oxc-resolver/binding-linux-x64-musl@npm:5.3.0"
   conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-openharmony-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.19.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-wasm32-wasi@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.19.1"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^1.1.1"
+  conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
@@ -3210,10 +3343,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-resolver/binding-win32-arm64-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@oxc-resolver/binding-win32-arm64-msvc@npm:5.3.0":
   version: 5.3.0
   resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:5.3.0"
   conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-ia32-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-ia32-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3698,6 +3852,15 @@ __metadata:
   version: 1.0.4
   resolution: "@tsconfig/node16@npm:1.0.4"
   checksum: 10c0/05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.1":
+  version: 0.10.2
+  resolution: "@tybys/wasm-util@npm:0.10.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
   languageName: node
   linkType: hard
 
@@ -5924,7 +6087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-context@npm:^0.1.8, eslint-import-context@npm:^0.1.9":
+"eslint-import-context@npm:^0.1.8":
   version: 0.1.9
   resolution: "eslint-import-context@npm:0.1.9"
   dependencies:
@@ -5936,6 +6099,21 @@ __metadata:
     unrs-resolver:
       optional: true
   checksum: 10c0/07851103443b70af681c5988e2702e681ff9b956e055e11d4bd9b2322847fa0d9e8da50c18fc7cb1165106b043f34fbd0384d7011c239465c4645c52132e56f3
+  languageName: node
+  linkType: hard
+
+"eslint-import-context@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eslint-import-context@npm:0.2.0"
+  dependencies:
+    get-tsconfig: "npm:^4.10.1"
+    stable-hash-x: "npm:^0.2.0"
+  peerDependencies:
+    oxc-resolver: ^11.0.0
+  peerDependenciesMeta:
+    oxc-resolver:
+      optional: true
+  checksum: 10c0/43d9f47e603eed7f0e865b3ba7707951136c26cbd5bdcaa1aca0bfc0d5b3aa938b1058286dbd9df10d47e8228831f2f9dc8f489a36846e1e05c60965dc83b1f5
   languageName: node
   linkType: hard
 
@@ -6102,7 +6280,7 @@ __metadata:
     eslint: "npm:^9.29.0"
     eslint-config-prettier: "npm:^10.1.5"
     eslint-doc-generator: "npm:^2.2.2"
-    eslint-import-context: "npm:^0.1.9"
+    eslint-import-context: "npm:^0.2.0"
     eslint-import-resolver-typescript: "npm:^4.4.4"
     eslint-import-resolver-webpack: "npm:^0.13.10"
     eslint-import-test-order-redirect: "link:./test/fixtures/order-redirect"
@@ -6127,6 +6305,7 @@ __metadata:
     minimatch: "npm:^9.0.3 || ^10.1.2"
     nano-staged: "npm:^0.8.0"
     npm-run-all2: "npm:^8.0.4"
+    oxc-resolver: "npm:^11.19.1"
     path-serializer: "npm:^0.5.0"
     premove: "npm:^4.0.0"
     prettier: "npm:^3.6.1"
@@ -6140,7 +6319,6 @@ __metadata:
     tsdown: "npm:^0.12.9"
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.56.0"
-    unrs-resolver: "npm:^1.9.2"
     yarn-berry-deduplicate: "npm:^6.1.3"
   peerDependencies:
     "@typescript-eslint/utils": ^8.56.0
@@ -10098,6 +10276,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxc-resolver@npm:^11.19.1":
+  version: 11.19.1
+  resolution: "oxc-resolver@npm:11.19.1"
+  dependencies:
+    "@oxc-resolver/binding-android-arm-eabi": "npm:11.19.1"
+    "@oxc-resolver/binding-android-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-darwin-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-darwin-x64": "npm:11.19.1"
+    "@oxc-resolver/binding-freebsd-x64": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm-gnueabihf": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm-musleabihf": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-ppc64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-riscv64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-riscv64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-s390x-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-x64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-x64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-openharmony-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-wasm32-wasi": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-arm64-msvc": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-ia32-msvc": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-x64-msvc": "npm:11.19.1"
+  dependenciesMeta:
+    "@oxc-resolver/binding-android-arm-eabi":
+      optional: true
+    "@oxc-resolver/binding-android-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-x64":
+      optional: true
+    "@oxc-resolver/binding-freebsd-x64":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-musl":
+      optional: true
+    "@oxc-resolver/binding-openharmony-arm64":
+      optional: true
+    "@oxc-resolver/binding-wasm32-wasi":
+      optional: true
+    "@oxc-resolver/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-ia32-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/8ac4eaffa9c0bcbb9f4f4a2b43786457ec5a68684d8776cb78b5a15ce3d1a79d3e67262aa3c635f98a0c1cd6cd56a31fcb05bffb9a286100056e4ab06b928833
+  languageName: node
+  linkType: hard
+
 "oxc-resolver@npm:^5.0.0":
   version: 5.3.0
   resolution: "oxc-resolver@npm:5.3.0"
@@ -13075,7 +13322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unrs-resolver@npm:^1.7.11, unrs-resolver@npm:^1.9.2":
+"unrs-resolver@npm:^1.7.11":
   version: 1.9.2
   resolution: "unrs-resolver@npm:1.9.2"
   dependencies:


### PR DESCRIPTION
## Summary

Resolves #412.

This PR migrates eslint-plugin-import-x from `unrs-resolver` to `oxc-resolver`, aligning with eslint-import-context's recent migration (v0.2.0).

### Changes
- Replace `unrs-resolver` with `oxc-resolver@^11.0.0`
- Update `eslint-import-context` to `^0.2.0`
- Update documentation references

## Behavioral Difference & Test Update

One test case was updated to accommodate a behavioral difference between resolvers.

### Background

The [original test](https://github.com/import-js/eslint-plugin-import/blob/main/tests/src/rules/no-duplicates.js#L110-L119) came from eslint-plugin-import. It verifies that `'./bar'` and `'bar'` (with `paths` setting) are detected as duplicates by resolving to the same file.

### Resolution Behaviors

| Resolver | Used By | `bar` resolves to | Spec |
|----------|---------|-------------------|------|
| browserify/resolve | eslint-plugin-import | `bar.js` | Node.js |
| unrs-resolver | eslint-plugin-import-x (old) | `bar.js` | Node.js |
| oxc-resolver | eslint-plugin-import-x (new) | `bar/index.js` | webpack |

The test fixtures include both `bar.js` and `bar/index.js` with different content.

### Why oxc-resolver Differs

This is **intentional** per oxc-resolver's design. From their [source code](https://github.com/oxc-project/oxc-resolver/blob/main/src/lib.rs#L933-L943):

> "Only load the file if it is targeting a `X/sub/dir`. Otherwise just load the directory. No modern package manager creates `node_modules/X.js`."

oxc-resolver follows webpack's [enhanced-resolve](https://github.com/webpack/enhanced-resolve) behavior rather than Node.js's algorithm. For bare specifiers like `require('bar')`, it assumes you want a directory (package) rather than a lone file.

### Our Solution

The test was updated to use `deprecated` instead of `bar`:
- `deprecated.js` exists without a conflicting `deprecated/` directory
- The test still verifies duplicate detection works correctly with `paths`
- Other tests depending on `bar/index.js` remain unaffected

We acknowledge this is a nuanced difference and are very open to feedback if the maintainers prefer an alternate approach ( (like adding a resolver option, keeping the original test and accepting the behavior change, or another solution), we're happy to adjust.

## Test Plan

- [x] `yarn build` succeeds
- [x] All 3015 tests pass
- [x] Pre-commit hooks pass (eslint, tsc)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate from `unrs-resolver` to `oxc-resolver`, updating dependencies, documentation, and tests to reflect the new resolver's behavior.
> 
>   - **Dependencies**:
>     - Replace `unrs-resolver` with `oxc-resolver@^11.0.0` in `package.json`.
>     - Update `eslint-import-context` to `^0.2.0` in `package.json`.
>   - **Documentation**:
>     - Update references from `unrs-resolver` to `oxc-resolver` in `README.md` and `resolvers/README.md`.
>   - **Tests**:
>     - Update test case in `test/rules/no-duplicates.spec.ts` to use `deprecated` instead of `bar` to accommodate `oxc-resolver` behavior.
>   - **Code**:
>     - Modify `src/node-resolver.ts` to use `oxc-resolver` instead of `unrs-resolver`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-plugin-import-x&utm_source=github&utm_medium=referral)<sup> for a2f0af3d99f384b4615e2fb3f0e6cdb5fd47354b. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched resolver implementation reference from `unrs-resolver` to `oxc-resolver`
  * Bumped `eslint-import-context` to v0.2.0 and updated dependencies

* **Documentation**
  * Updated README and resolver docs to reflect the resolver name change

* **Tests**
  * Adjusted an import test case and its expected autofix output to use a trailing slash

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/un-ts/eslint-plugin-import-x/pull/445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->