### PR TITLE
fix: make `extensions` handle `.d.ts` correctly

### DIFF
--- a/.changeset/fix-extensions-dts.md
+++ b/.changeset/fix-extensions-dts.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+Make `extensions` handle `.d.ts` correctly

--- a/src/rules/extensions.ts
+++ b/src/rules/extensions.ts
@@ -16,6 +16,8 @@ import {
   stringifyPath,
 } from '../utils/index.js'
 
+const dtsRe = /\.d\.[cm]?ts$/
+
 const modifierValues = ['always', 'ignorePackages', 'never'] as const
 
 const modifierSchema = {
@@ -332,7 +334,7 @@ export default createRule<Options, MessageId>({
         // for .d.ts/.d.mts/.d.cts, use the import path extension instead.
         const extension = path
           .extname(
-            resolvedPath && /\.d\.[cm]?ts$/.test(resolvedPath)
+            resolvedPath && dtsRe.test(resolvedPath)
               ? importPath
               : resolvedPath || importPath,
           )

--- a/src/rules/extensions.ts
+++ b/src/rules/extensions.ts
@@ -328,9 +328,15 @@ export default createRule<Options, MessageId>({
 
         const resolvedPath = resolve(importPath, context)
 
-        // get extension from resolved path, if possible.
-        // for unresolved, use source value.
-        const extension = path.extname(resolvedPath || importPath).slice(1)
+        // get extension from resolved path, or source value if unresolved.
+        // for .d.ts/.d.mts/.d.cts, use the import path extension instead.
+        const extension = path
+          .extname(
+            resolvedPath && /\.d\.[cm]?ts$/.test(resolvedPath)
+              ? importPath
+              : resolvedPath || importPath,
+          )
+          .slice(1)
 
         // determine if this is a module
         const isPackage =

--- a/test/fixtures/dist-import/index.d.ts
+++ b/test/fixtures/dist-import/index.d.ts
@@ -1,0 +1,1 @@
+export declare const foo: string;

--- a/test/fixtures/dist-import/index.d.ts
+++ b/test/fixtures/dist-import/index.d.ts
@@ -1,1 +1,1 @@
-export declare const foo: string;
+export declare const foo: string

--- a/test/fixtures/dist-import/index.js
+++ b/test/fixtures/dist-import/index.js
@@ -1,0 +1,1 @@
+export const foo = 'bar';

--- a/test/fixtures/dist-import/index.js
+++ b/test/fixtures/dist-import/index.js
@@ -1,1 +1,1 @@
-export const foo = 'bar';
+export const foo = 'bar'

--- a/test/rules/extensions.spec.ts
+++ b/test/rules/extensions.spec.ts
@@ -1249,6 +1249,12 @@ describe('TypeScript', () => {
         options: ['always', { checkTypeImports: true }],
       }),
 
+      // .js import that resolves to .d.ts should not demand .ts extension
+      tValid({
+        code: 'import { foo } from "./dist-import/index.js";',
+        options: ['always'],
+      }),
+
       // pathGroupOverrides: no patterns match good bespoke specifiers
       tValid({
         code: `


### PR DESCRIPTION
When importing `.js` and a `.d.ts` file with the same name exists, like for example when importing from a `dist` directory, the rule incorrectly demanded the import to be changed to `.ts` (a non-existing file).

Likely fixes https://github.com/un-ts/eslint-plugin-import-x/issues/164.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected extension detection so TypeScript declaration variants (.d.ts, .d.mts, .d.cts) are recognized during import resolution, preserving normal behavior for regular files.

* **Tests**
  * Added a test case covering type-declaration resolution where a .js import resolves to a declaration file.

* **New Files**
  * Added example module and matching type declaration used by the new test.

* **Chores**
  * Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->