### PR TITLE
fix: move @package-json/types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     }
   },
   "dependencies": {
-    "@package-json/types": "^0.0.12",
     "@typescript-eslint/types": "^8.56.0",
     "comment-parser": "^1.4.1",
     "debug": "^4.4.1",
@@ -108,6 +107,7 @@
     "@commitlint/cli": "^19.8.1",
     "@eslint/import-test-order-redirect-scoped": "link:./test/fixtures/order-redirect-scoped",
     "@eslint/js": "^9.29.0",
+    "@package-json/types": "^0.0.12",
     "@swc-node/jest": "^1.8.13",
     "@swc/core": "^1.12.7",
     "@swc/helpers": "^0.5.17",

--- a/src/rules/no-duplicates.ts
+++ b/src/rules/no-duplicates.ts
@@ -1,10 +1,10 @@
-import type { PackageJson } from '@package-json/types'
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import * as semver from 'semver'
 
 import { cjsRequire } from '../require.js'
 import type { RuleContext } from '../types.js'
 import { createRule, lazy, resolve } from '../utils/index.js'
+import type { PackageJson } from '../utils/index.js'
 
 // a user might set prefer-inline but not have a supporting TypeScript version.  Flow does not support inline types so this should fail in that case as well.
 // pre-calculate if the TypeScript version is supported

--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { PackageJson } from '@package-json/types'
 import type { TSESTree } from '@typescript-eslint/utils'
 import { minimatch } from 'minimatch'
 
@@ -15,6 +14,7 @@ import {
   getFilePackageName,
   getNpmInstallCommand,
 } from '../utils/index.js'
+import type { PackageJson } from '../utils/index.js'
 
 export type PackageDeps = ReturnType<typeof extractDepFields>
 

--- a/src/utils/read-pkg-up.ts
+++ b/src/utils/read-pkg-up.ts
@@ -1,8 +1,11 @@
 import fs from 'node:fs'
 
-import type { PackageJson } from '@package-json/types'
-
 import { pkgUp } from './pkg-up.js'
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+export type PackageJson = typeof import('@package-json/types') extends never
+  ? Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  : import('@package-json/types').PackageJson // eslint-disable-line @typescript-eslint/consistent-type-imports
 
 function stripBOM(str: string) {
   return str.replace(/^\uFEFF/, '')


### PR DESCRIPTION
PackageJson is only used internally in development. Import the type dinamically and check its existence.

Fixes https://github.com/un-ts/eslint-plugin-import-x/issues/471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `@package-json/types` package to project dependencies and devDependencies
  * Refactored internal type imports to use a centralized utility module
  * Consolidated package.json type definitions across rule modules for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->