### PR TITLE
feat: support RegExp in ignore

### DIFF
--- a/.changeset/eight-oranges-lie.md
+++ b/.changeset/eight-oranges-lie.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": minor
+---
+
+Support `RegExp` in the `import-x/ignore` setting and the `ignore` option of the `no-unresolved` rule.

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ Also, the following `import-x/ignore` patterns will overrule this list.
 
 ### `import-x/ignore`
 
-A list of regex strings that, if matched by a path, will
+A list of `RegExp` or `RegExp` pattern strings that, if matched by a path, will
 not report the matching module if no `export`s are found.
 In practice, this means rules other than [`no-unresolved`](./docs/rules/no-unresolved.md#ignore) will not report on any
 `import`s with (absolute filesystem) paths matching this pattern.

--- a/docs/rules/no-unresolved.md
+++ b/docs/rules/no-unresolved.md
@@ -72,7 +72,7 @@ require(['./foo'], function (foo) {
 
 This rule has its own ignore list, separate from [`import-x/ignore`]. This is because you may want to know whether a module can be located, regardless of whether it can be parsed for exports: `node_modules`, CoffeeScript files, etc. are all good to resolve properly, but will not be parsed if configured as such via [`import-x/ignore`].
 
-To suppress errors from files that may not be properly resolved by your [resolver settings](../../README.md#resolver-plugins), you may add an `ignore` key with an array of `RegExp` pattern strings:
+To suppress errors from files that may not be properly resolved by your [resolver settings](../../README.md#resolver-plugins), you may add an `ignore` key with an array of `RegExp` or `RegExp` pattern strings:
 
 ```js
 /*eslint import-x/no-unresolved: [2, { ignore: ['\\.img$'] }]*/

--- a/src/utils/module-visitor.ts
+++ b/src/utils/module-visitor.ts
@@ -15,7 +15,7 @@ export interface ModuleOptions {
   amd?: boolean
   commonjs?: boolean
   esmodule?: boolean
-  ignore?: string[]
+  ignore?: Array<RegExp | string>
 }
 
 /**
@@ -203,7 +203,6 @@ export function makeOptionsSchema(
       ignore: {
         type: 'array',
         minItems: 1,
-        items: { type: 'string' },
         uniqueItems: true,
       },
     },

--- a/test/rules/no-unresolved.spec.ts
+++ b/test/rules/no-unresolved.spec.ts
@@ -155,6 +155,11 @@ function runResolverTests(resolver: 'node' | 'webpack') {
         settings: { 'import-x/ignore': [String.raw`^\./fake/`] },
         errors: [createError('unresolved', './reallyfake/module')],
       }),
+      tInvalid({
+        code: 'import ReallyFake from "./ReallyFake/module"',
+        settings: { 'import-x/ignore': /^\.\/fake/i },
+        errors: [createError('unresolved', './ReallyFake/module')],
+      }),
 
       tInvalid({
         code: "import bar from './baz';",
@@ -407,10 +412,18 @@ ruleTester.run('no-unresolved ignore list', rule, {
       code: 'import "./test.gif"',
       options: [{ ignore: ['.png$', '.gif$'] }],
     }),
+    tValid({
+      code: 'import "./test.GIF"',
+      options: [{ ignore: [/\.png$/i, /\.gif$/i] }],
+    }),
 
     tValid({
       code: 'import "./test.png"',
       options: [{ ignore: ['.png$', '.gif$'] }],
+    }),
+    tValid({
+      code: 'import "./test.png"',
+      options: [{ ignore: [/\.(png|gif)$/] }],
     }),
   ],
 
@@ -420,10 +433,20 @@ ruleTester.run('no-unresolved ignore list', rule, {
       options: [{ ignore: ['.png$'] }],
       errors: [createError('unresolved', './test.gif')],
     }),
+    tInvalid({
+      code: 'import "./test.gif"',
+      options: [{ ignore: [/\.png$/] }],
+      errors: [createError('unresolved', './test.gif')],
+    }),
 
     tInvalid({
       code: 'import "./test.png"',
       options: [{ ignore: ['.gif$'] }],
+      errors: [createError('unresolved', './test.png')],
+    }),
+    tInvalid({
+      code: 'import "./test.png"',
+      options: [{ ignore: [/\.gif$/] }],
       errors: [createError('unresolved', './test.png')],
     }),
   ],


### PR DESCRIPTION
Fix https://github.com/un-ts/eslint-plugin-import-x/issues/464

Support `RegExp` in the `import-x/ignore` setting and the `ignore` option of the `no-unresolved` rule.

---

I removed the item type (as with the `ignore` option in the [`unicorn/catch-error-name`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v63.0.0/rules/catch-error-name.js#L108-L111) rule), because JSONSchema doesn't have a type for `RegExp`.

I didn't change the [`ignore` to `ignoreRegExps`](https://github.com/un-ts/eslint-plugin-import-x/blob/v4.16.2/src/utils/module-visitor.ts#L32) conversion because the [`RegExp` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp#pattern) accepts another `RegExp` as a parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `ignore` option now accepts both RegExp objects and string patterns for more flexible module-ignore matching.

* **Documentation**
  * Docs updated to clarify RegExp and string pattern support for the `ignore` option across relevant files.

* **Tests**
  * Added tests covering RegExp-based ignores, including case-insensitive patterns and common file-type patterns.

* **Chores**
  * Minor package version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->