### PR TITLE
fix: strip querystrings and hash fragments when checking for file existence

### DIFF
--- a/.changeset/khaki-lemons-divide.md
+++ b/.changeset/khaki-lemons-divide.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: strip querystrings and hash fragments when checking for file existence

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -61,6 +61,10 @@ export function fileExistsWithCaseSync(
   if (filepath === null) {
     return true
   }
+
+  // Remove any querystrings from the import path
+  filepath = filepath.split('?')[0]
+
   if (filepath.toLowerCase() === process.cwd().toLowerCase() && !strict) {
     return true
   }

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -71,6 +71,10 @@ export function fileExistsWithCaseSync(
   if (filepath === null) {
     return true
   }
+
+  // Remove any querystrings from the import path
+  filepath = filepath.split('?')[0]
+
   if (filepath.toLowerCase() === process.cwd().toLowerCase() && !strict) {
     return true
   }

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -72,8 +72,8 @@ export function fileExistsWithCaseSync(
     return true
   }
 
-  // Remove any querystrings from the import path
-  filepath = filepath.split('?')[0]
+  // Remove any querystrings and hash fragments from the import path
+  filepath = filepath.split(/[?#]/)[0]
 
   if (filepath.toLowerCase() === process.cwd().toLowerCase() && !strict) {
     return true

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -72,12 +72,10 @@ export function fileExistsWithCaseSync(
     return true
   }
 
-  // Remove any querystrings and hash fragments from the import path
-  filepath = filepath.split(/[?#]/)[0]
-
   if (filepath.toLowerCase() === process.cwd().toLowerCase() && !strict) {
     return true
   }
+
   const parsedPath = path.parse(filepath)
   const dir = parsedPath.dir
 
@@ -92,15 +90,36 @@ export function fileExistsWithCaseSync(
   } else {
     try {
       const filenames = fs.readdirSync(dir)
-      result = filenames.includes(parsedPath.base)
-        ? fileExistsWithCaseSync(dir, cacheSettings, strict, false)
-        : !leaf &&
+      if (filenames.includes(parsedPath.base)) {
+        result = fileExistsWithCaseSync(dir, cacheSettings, strict, false)
+      } else {
+        const baseLowerCase = parsedPath.base.toLowerCase()
+        const hasCaseInsensitiveMatch = filenames.some(
+          p => p.toLowerCase() === baseLowerCase,
+        )
+
+        const isMissing = !hasCaseInsensitiveMatch
+
+        if (isMissing && leaf) {
+          const queryIndex = filepath.lastIndexOf('?')
+          const hashIndex = filepath.lastIndexOf('#')
+          const index = Math.max(queryIndex, hashIndex)
+
+          result =
+            index > 0
+              ? fileExistsWithCaseSync(
+                  filepath.slice(0, index),
+                  cacheSettings,
+                  strict,
+                )
+              : false
+        } else {
           // We tolerate case-insensitive matches if there are no case-insensitive matches.
           // It'll fail anyway on the leaf node if the file truly doesn't exist (if it doesn't
           // fail it's that we're probably working with a virtual in-memory filesystem).
-          !filenames.some(
-            p => p.toLowerCase() === parsedPath.base.toLowerCase(),
-          )
+          result = isMissing && !leaf
+        }
+      }
     } catch (error) {
       if (isDirectoryAccessError(error)) {
         result = true

--- a/test/rules/no-unresolved.spec.ts
+++ b/test/rules/no-unresolved.spec.ts
@@ -48,6 +48,7 @@ function runResolverTests(resolver: 'node' | 'webpack') {
       }),
 
       tValid({ code: 'import foo from "./bar";' }),
+      tValid({ code: 'import foo from "./bar?qs";' }),
       tValid({ code: "import bar from './bar.js';" }),
       tValid({ code: "import {someThing} from './test-module';" }),
       tValid({ code: "import fs from 'fs';" }),

--- a/test/rules/no-unresolved.spec.ts
+++ b/test/rules/no-unresolved.spec.ts
@@ -49,7 +49,9 @@ function runResolverTests(resolver: 'node' | 'webpack') {
 
       tValid({ code: 'import foo from "./bar";' }),
       tValid({ code: 'import foo from "./bar?qs";' }),
-      tValid({ code: 'import foo from "./bar#hash";' }),
+      ...(resolver === 'node'
+        ? [tValid({ code: 'import foo from "./bar#hash";' })]
+        : []),
       tValid({ code: 'import foo from "./bar?qs#hash";' }),
       tValid({ code: "import bar from './bar.js';" }),
       tValid({ code: "import {someThing} from './test-module';" }),

--- a/test/rules/no-unresolved.spec.ts
+++ b/test/rules/no-unresolved.spec.ts
@@ -49,6 +49,8 @@ function runResolverTests(resolver: 'node' | 'webpack') {
 
       tValid({ code: 'import foo from "./bar";' }),
       tValid({ code: 'import foo from "./bar?qs";' }),
+      tValid({ code: 'import foo from "./bar#hash";' }),
+      tValid({ code: 'import foo from "./bar?qs#hash";' }),
       tValid({ code: "import bar from './bar.js';" }),
       tValid({ code: "import {someThing} from './test-module';" }),
       tValid({ code: "import fs from 'fs';" }),

--- a/test/utils/resolve.spec.ts
+++ b/test/utils/resolve.spec.ts
@@ -477,6 +477,13 @@ describe('resolve', () => {
       expect(fileExistsWithCaseSync(file, cacheSettings)).toBe(false)
     })
 
+    it.each(['?qs', '#hash', '?qs#hash'])(
+      'falls back from %s when detecting case mismatch',
+      suffix => {
+        expect(fileExistsWithCaseSync(file + suffix, cacheSettings)).toBe(false)
+      },
+    )
+
     it('detecting case does not include parent folder path (issue #720)', () => {
       const f = path.resolve(
         process.cwd().toUpperCase(),


### PR DESCRIPTION
- fixes: #473

This prevents false positives on case mismatches on case sensitive file systems when imports have a querystring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file resolution for import specifiers that include query strings and/or hash fragments, ensuring consistent matching to the correct file.
* **Tests**
  * Expanded resolver and case-sensitivity coverage to include URL-like specifiers (e.g., `?query`, `#hash`, and combined forms) across supported resolvers.
* **Chores**
  * Updated the package patch release notes for the resolution fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->