### PR TITLE
fix: memoize legacyNodeResolve resolver to avoid native memory leak

### DIFF
--- a/.changeset/cuddly-bees-grow.md
+++ b/.changeset/cuddly-bees-grow.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix: memoize legacyNodeResolve resolver to avoid native memory leak

--- a/src/node-resolver.ts
+++ b/src/node-resolver.ts
@@ -6,12 +6,16 @@ import type { NapiResolveOptions } from 'unrs-resolver'
 
 import type { NewResolver } from './types.js'
 
+export type NodeResolver = NewResolver & {
+  clearCache: () => void
+}
+
 export function createNodeResolver({
   extensions = ['.mjs', '.cjs', '.js', '.json', '.node'],
   conditionNames = ['import', 'require', 'default'],
   mainFields = ['module', 'main'],
   ...restOptions
-}: NapiResolveOptions = {}): NewResolver {
+}: NapiResolveOptions = {}): NodeResolver {
   const resolver = new ResolverFactory({
     extensions,
     conditionNames,
@@ -38,6 +42,9 @@ export function createNodeResolver({
         //
       }
       return { found: false }
+    },
+    clearCache() {
+      resolver.clearCache()
     },
   }
 }

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -125,6 +125,36 @@ function isValidNewResolver(resolver: unknown): resolver is NewResolver {
   return true
 }
 
+// Memoize resolver instances by their option signature.
+//
+// `createNodeResolver` constructs a fresh `unrs-resolver` `ResolverFactory` on
+// every call. `unrs-resolver` is a Rust binding that allocates native memory
+// not visible to V8's heap limits, so creating one per import resolution
+// causes RSS to grow without bound over a lint run and eventually OOMs the
+// worker — observed on a large lerna monorepo where a single ESLint worker
+// peaked at >19 GB before the OOM killer fired. Bumping `--max-old-space-size`
+// does not help because the leak is in native memory, not the JS heap.
+//
+// In practice the resolver options are constant across calls within a single
+// lint run, so the cache is effectively a singleton. The JSON-stringified key
+// is small and cheap to compute relative to constructing a new resolver.
+const cachedNodeResolvers = new Map<
+  string,
+  ReturnType<typeof createNodeResolver>
+>()
+
+function getCachedNodeResolver(
+  opts: Parameters<typeof createNodeResolver>[0],
+) {
+  const key = JSON.stringify(opts)
+  let resolver = cachedNodeResolvers.get(key)
+  if (!resolver) {
+    resolver = createNodeResolver(opts)
+    cachedNodeResolvers.set(key, resolver)
+  }
+  return resolver
+}
+
 function legacyNodeResolve(
   resolverOptions: NodeResolverOptions,
   context: ChildContext | RuleContext,
@@ -151,7 +181,7 @@ function legacyNodeResolve(
   // TODO: change the default behavior to align node itself
   const symlinks = preserveSymlinks === false
 
-  const resolver = createNodeResolver({
+  const resolver = getCachedNodeResolver({
     extensions: normalizedExtensions,
     builtinModules: includeCoreModules !== false,
     modules,
@@ -175,7 +205,7 @@ function legacyNodeResolve(
       : normalizedPaths
 
     if (paths.length > 0) {
-      const resolver = createNodeResolver({
+      const resolver = getCachedNodeResolver({
         extensions: normalizedExtensions,
         builtinModules: includeCoreModules !== false,
         modules: paths,

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -6,6 +6,7 @@ import { setRuleContext } from 'eslint-import-context'
 import { stableHash } from 'stable-hash-x'
 
 import { createNodeResolver } from '../node-resolver.js'
+import type { NodeResolver } from '../node-resolver.js'
 import { cjsRequire } from '../require.js'
 import type {
   ChildContext,
@@ -140,10 +141,7 @@ function isValidNewResolver(resolver: unknown): resolver is NewResolver {
 // is small and cheap to compute relative to constructing a new resolver, and
 // matches the hashing already used for `fileExistsCache` elsewhere in this
 // file.
-const cachedNodeResolvers = new Map<
-  string,
-  ReturnType<typeof createNodeResolver>
->()
+const cachedNodeResolvers = new Map<string, NodeResolver>()
 
 function getCachedNodeResolver(opts: Parameters<typeof createNodeResolver>[0]) {
   const key = stableHash(opts)
@@ -153,6 +151,20 @@ function getCachedNodeResolver(opts: Parameters<typeof createNodeResolver>[0]) {
     cachedNodeResolvers.set(key, resolver)
   }
   return resolver
+}
+
+/**
+ * Clear all memoized `unrs-resolver` instances and their internal FS caches.
+ *
+ * This is primarily useful in tests where files are created, renamed, or
+ * deleted between resolve calls. In production lint runs files don't change
+ * mid-run, so the cache is safe to keep for the lifetime of the process.
+ */
+export function clearCachedNodeResolvers() {
+  for (const resolver of cachedNodeResolvers.values()) {
+    resolver.clearCache()
+  }
+  cachedNodeResolvers.clear()
 }
 
 function legacyNodeResolve(

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -136,8 +136,10 @@ function isValidNewResolver(resolver: unknown): resolver is NewResolver {
 // does not help because the leak is in native memory, not the JS heap.
 //
 // In practice the resolver options are constant across calls within a single
-// lint run, so the cache is effectively a singleton. The JSON-stringified key
-// is small and cheap to compute relative to constructing a new resolver.
+// lint run, so the cache is effectively a singleton. The `stable-hash-x` key
+// is small and cheap to compute relative to constructing a new resolver, and
+// matches the hashing already used for `fileExistsCache` elsewhere in this
+// file.
 const cachedNodeResolvers = new Map<
   string,
   ReturnType<typeof createNodeResolver>
@@ -146,7 +148,7 @@ const cachedNodeResolvers = new Map<
 function getCachedNodeResolver(
   opts: Parameters<typeof createNodeResolver>[0],
 ) {
-  const key = JSON.stringify(opts)
+  const key = stableHash(opts)
   let resolver = cachedNodeResolvers.get(key)
   if (!resolver) {
     resolver = createNodeResolver(opts)

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -145,9 +145,7 @@ const cachedNodeResolvers = new Map<
   ReturnType<typeof createNodeResolver>
 >()
 
-function getCachedNodeResolver(
-  opts: Parameters<typeof createNodeResolver>[0],
-) {
+function getCachedNodeResolver(opts: Parameters<typeof createNodeResolver>[0]) {
   const key = stableHash(opts)
   let resolver = cachedNodeResolvers.get(key)
   if (!resolver) {

--- a/test/utils/resolve.spec.ts
+++ b/test/utils/resolve.spec.ts
@@ -17,6 +17,7 @@ import type {
 } from 'eslint-plugin-import-x'
 import {
   CASE_SENSITIVE_FS,
+  clearCachedNodeResolvers,
   fileExistsWithCaseSync,
   relative,
   resolve,
@@ -524,6 +525,10 @@ describe('resolve', () => {
         beforeAll(() =>
           fs.promises.rename(testFilePath(original), testFilePath(changed)),
         )
+
+        // The memoized unrs-resolver instances cache FS lookups internally.
+        // After a rename we must clear them so the resolver sees the new state.
+        beforeAll(() => clearCachedNodeResolvers())
 
         beforeAll(() => {
           const exists = fs.existsSync(testFilePath(changed))


### PR DESCRIPTION
## Problem

`legacyNodeResolve` in `src/utils/resolve.ts` constructs a fresh `unrs-resolver` `ResolverFactory` via `createNodeResolver` on every import resolution. `unrs-resolver` is a Rust binding that allocates **native memory** which is **not visible to V8's heap limits**, so per-call construction causes RSS to grow without bound over the course of a lint run.

We hit this on a large lerna monorepo (apify/apify-core, ~60 workspace packages, thousands of files). A single ESLint worker peaked at >19 GB RSS before being OOM-killed by the runner. Bumping `--max-old-space-size` did not help — the leak is in native memory, not the JS heap.

The dominant time-spender shown by `TIMING=all` is `import-x/no-cycle`, but the *memory* hot-spot is the resolver. Disabling `no-cycle` entirely reduced peak RSS by only ~2.5 GB (from ~12.5 GB to ~10 GB single-worker) — confirming the leak is in the per-call resolver allocation, not the cycle traversal.

## Fix

Memoize `unrs-resolver` instances by their option signature.

In practice the resolver options object is constant across calls within a single lint run, so the cache is effectively a singleton — but JSON-stringifying the options is cheap enough to handle the multi-resolver-config case correctly, and doesn't risk a stale cache if options ever vary.

## Verification

Local repro on apify/apify-core's `src/packages` (~60 workspace packages):

| variant | concurrency | heap | result | peak RSS |
|---|---|---|---|---|
| baseline (master) | auto | 8 GB | OOM (worker) | ~22 GB |
| baseline | auto | 16 GB | OOM (worker) | ~20 GB |
| baseline | 4 | 16 GB | OOM (worker) | ~18 GB |
| baseline | 1 | 12 GB | passes (4m13s on CI) | ~10 GB |
| **with this patch** | **auto** | **8 GB** | **passes (~4m local, ~3m CI)** | **~20 GB** |
| with this patch | 4 | 8 GB | passes (1m47s local) | ~24 GB |

So this restores the ability to use `--concurrency=auto` with the default 8 GB heap on a typical CI runner.

## Notes

- `legacyNodeResolve` is the path taken when no `import-x/resolver-next` is configured and the resolver name is in `LEGACY_NODE_RESOLVERS`. That covers the default `node` resolver, which is what most consumers use, so this fix benefits the common case.
- The cache uses a `Map<string, Resolver>` keyed by `JSON.stringify(opts)`. A `WeakMap` keyed by the options object would be slightly more efficient but doesn't work because callers often pass freshly-constructed options objects rather than reusing the same reference.
- I didn't add a test because the leak only manifests over thousands of resolutions and would need a fixture monorepo to reproduce. Happy to add one if you'd like — let me know what shape you'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Resolver instances are now memoized per option set, avoiding repeated resolver creation and improving performance and memory usage during repeated resolutions.
  * Added a public API to clear memoized resolver caches, including each resolver’s internal cache.

* **Bug Fixes**
  * Improved `legacyNodeResolve` behavior by reusing cached resolvers and preventing a native memory leak scenario.

* **Tests**
  * Updated resolver tests to clear cached state after filesystem changes to ensure assertions reflect the latest paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->