### PR TITLE
fix(no-extraneous-dependencies): merge deps from closest package.json

### DIFF
--- a/src/rules/no-extraneous-dependencies.ts
+++ b/src/rules/no-extraneous-dependencies.ts
@@ -69,12 +69,37 @@ function getDependencies(context: RuleContext, packageDir?: string | string[]) {
   let paths: string[] = []
 
   try {
-    let packageContent: PackageDeps = {
+    const packageContent: PackageDeps = {
       dependencies: {},
       devDependencies: {},
       optionalDependencies: {},
       peerDependencies: {},
       bundledDependencies: [],
+    }
+
+    // Always merge in deps from the closest `package.json` relative to the
+    // linted file. Without this, setting `packageDir` to point at a root
+    // (shared) `package.json` in a monorepo makes the rule ignore the
+    // workspace package's own deps — every dep declared in the workspace
+    // package's `package.json` gets flagged as "should be listed in the
+    // project's dependencies". Checking the closest package.json first
+    // restores the expected behavior in lerna / npm-workspaces / pnpm-
+    // workspaces layouts.
+    const closestPackageJsonPath = pkgUp({
+      cwd: context.physicalFilename,
+    })
+
+    if (closestPackageJsonPath) {
+      const closestPackageContent = getPackageDepFields(
+        closestPackageJsonPath,
+        false,
+      )
+      if (closestPackageContent) {
+        for (const depsKey of Object.keys(packageContent)) {
+          const key = depsKey as keyof PackageDeps
+          Object.assign(packageContent[key], closestPackageContent[key])
+        }
+      }
     }
 
     if (packageDir && packageDir.length > 0) {
@@ -83,31 +108,18 @@ function getDependencies(context: RuleContext, packageDir?: string | string[]) {
         : [path.resolve(packageDir)]
     }
 
-    if (paths.length > 0) {
-      // use rule config to find package.json
-      for (const dir of paths) {
-        const packageJsonPath = path.resolve(dir, 'package.json')
-        const packageContent_ = getPackageDepFields(
-          packageJsonPath,
-          paths.length === 1,
-        )
-        if (packageContent_) {
-          for (const depsKey of Object.keys(packageContent)) {
-            const key = depsKey as keyof PackageDeps
-            Object.assign(packageContent[key], packageContent_[key])
-          }
-        }
-      }
-    } else {
-      // use closest package.json
-      const packageJsonPath = pkgUp({
-        cwd: context.physicalFilename,
-      })!
-
-      const packageContent_ = getPackageDepFields(packageJsonPath, false)
-
+    // Layer in any deps from `packageDir` on top of the closest match.
+    for (const dir of paths) {
+      const packageJsonPath = path.resolve(dir, 'package.json')
+      const packageContent_ = getPackageDepFields(
+        packageJsonPath,
+        paths.length === 1,
+      )
       if (packageContent_) {
-        packageContent = packageContent_
+        for (const depsKey of Object.keys(packageContent)) {
+          const key = depsKey as keyof PackageDeps
+          Object.assign(packageContent[key], packageContent_[key])
+        }
       }
     }
 

--- a/test/rules/no-extraneous-dependencies.spec.ts
+++ b/test/rules/no-extraneous-dependencies.spec.ts
@@ -238,6 +238,31 @@ ruleTester.run('no-extraneous-dependencies', rule, {
         { packageDir: packageDirMonoRepoRoot, whitelist: ['not-a-dependency'] },
       ],
     }),
+
+    // Closest package.json is always merged when packageDir is set.
+    // File is inside nested-package/ which has react, so react is found
+    // even though packageDir only points to monorepo root (which lacks react).
+    tValid({
+      code: 'import react from "react";',
+      filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
+      options: [{ packageDir: packageDirMonoRepoRoot }],
+    }),
+
+    // Deps from both the closest package.json AND packageDir are merged.
+    // right-pad is only in monorepo root, react is only in nested-package.
+    // File is in nested-package, packageDir points to root — both should be found.
+    tValid({
+      code: 'import rightpad from "right-pad";',
+      filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
+      options: [{ packageDir: packageDirMonoRepoRoot }],
+    }),
+
+    // When closest package.json IS the packageDir, behavior is unchanged.
+    tValid({
+      code: 'import rightpad from "right-pad";',
+      filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
+      options: [{ packageDir: packageDirMonoRepoRoot }],
+    }),
   ],
   invalid: [
     tInvalid({
@@ -368,12 +393,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     tInvalid({
       code: 'import react from "react";',
       filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
-      errors: [{ messageId: 'missing', data: { packageName: 'react' } }],
-    }),
-    tInvalid({
-      code: 'import react from "react";',
-      filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
-      options: [{ packageDir: packageDirMonoRepoRoot }],
       errors: [{ messageId: 'missing', data: { packageName: 'react' } }],
     }),
     tInvalid({


### PR DESCRIPTION
## Problem

In a monorepo (lerna / npm workspaces / pnpm workspaces), the typical `eslint.config.js` for the root sets `packageDir` to a list of paths that point at the repo root so shared devDeps are discoverable:

\`\`\`js
'import-x/no-extraneous-dependencies': ['error', {
  packageDir: ['.', '../..', '../../..'],
}]
\`\`\`

With the current rule, setting \`packageDir\` makes the rule ignore the **closest** \`package.json\` entirely. That's a problem: each workspace package has its own \`package.json\` with its own dependencies (that's the whole point of a workspace), and those deps become invisible to the rule. Every dep declared in the workspace package — \`lodash\`, internal \`@apify-packages/*\` workspace packages, etc. — gets reported as \"should be listed in the project's dependencies\" even though it literally is.

Concretely, on [apify/apify-core](https://github.com/apify/apify-core) (~60 lerna workspace packages), the migration from \`eslint-plugin-import\` to \`eslint-plugin-import-x\` surfaced hundreds of false positives like this:

\`\`\`
src/packages/action-queue/src/action_queue.ts
  1:1  error  'lodash' should be listed in the project's dependencies. Run 'npm i lodash' to add it                                              import-x/no-extraneous-dependencies
  3:1  error  '@apify/log' should be listed in the project's dependencies. Run 'npm i @apify/log' to add it                                      import-x/no-extraneous-dependencies
  5:1  error  '@apify-packages/aws' should be listed in the project's dependencies. Run 'npm i @apify-packages/aws' to add it                    import-x/no-extraneous-dependencies
\`\`\`

...even though \`src/packages/action-queue/package.json\` declares all three.

\`apify-core\` has been carrying a local \`patch-package\` patch on \`eslint-plugin-import\` to work around this for years. We re-applied the same patch on \`eslint-plugin-import-x\` during the migration (see [apify/apify-core#26946](https://github.com/apify/apify-core/pull/26946)). This PR upstreams that fix so we can drop the patch.

## Fix

Always seed \`packageContent\` from the closest \`package.json\` walking up from \`context.physicalFilename\`, then layer any \`packageDir\` entries on top:

- **packageDir not set** → behaves like before (use closest only).
- **packageDir set** → closest wins the base layer; any extra deps declared in the paths listed in \`packageDir\` are merged in on top (so repo-root shared devDeps still work).

The order is deliberate: entries later in \`packageDir\` can still override the closest match if there's a version conflict, matching the existing behavior where later \`packageDir\` entries already override earlier ones.

## Verification

After this PR + re-applying it as a \`patch-package\` patch against \`eslint-plugin-import-x\` 4.16.2 locally: \`npx eslint ./src/packages\` on apify-core completes cleanly. Without it: hundreds of false-positive \"should be listed in the project's dependencies\" errors.

## Companion PR

This is the second of two fixes I've sent to address the CI breakage caused by this issue. The first one ([#481](https://github.com/un-ts/eslint-plugin-import-x/pull/481)) was about native memory leaking in \`legacyNodeResolve\`; you suggested migrating to \`import-x/resolver-next\` which we've done via [apify/apify-eslint-config#42](https://github.com/apify/apify-eslint-config/pull/42). This one is a different bug — it's in the rule's deps-lookup, not the resolver — so the \`resolver-next\` migration doesn't cover it.

Happy to add a test; let me know what shape you'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency resolution so the nearest package manifest is always used as the base and configured package directories are layered on top, improving correctness for monorepos and nested packages.
* **Tests**
  * Added coverage for monorepo/nested-package scenarios and adjusted expectations to reflect the corrected resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->