### PR TITLE
fix: make `extensions` rule check Node.js subpath imports

### DIFF
--- a/.changeset/extensions-subpath-imports.md
+++ b/.changeset/extensions-subpath-imports.md
@@ -1,0 +1,7 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+Make the `extensions` rule check Node.js subpath imports (specifiers starting with `#`, e.g. `#utils/helper`). Previously `parsePath` treated a leading `#` as a URL hash fragment, so the rule skipped extension validation for these imports.
+
+Note: single-segment subpath imports without a slash (e.g. `#dep`) are still skipped by the existing external-root-module classification; fixing that is deferred to avoid expanding scope.

--- a/src/utils/parse-path.ts
+++ b/src/utils/parse-path.ts
@@ -7,7 +7,9 @@ export interface ParsedPath {
 export const parsePath = (path: string): ParsedPath => {
   const hashIndex = path.indexOf('#')
   const queryIndex = path.indexOf('?')
-  const hasHash = hashIndex !== -1
+  // A `#` at index 0 is the sigil for a Node.js subpath import (e.g.
+  // `#utils/helper`), not a URL hash fragment, so it must stay in `pathname`.
+  const hasHash = hashIndex > 0
   const hash = hasHash ? path.slice(hashIndex) : ''
   const hasQuery = queryIndex !== -1 && (!hasHash || queryIndex < hashIndex)
   const query = hasQuery

--- a/test/rules/extensions.spec.ts
+++ b/test/rules/extensions.spec.ts
@@ -76,6 +76,19 @@ ruleTester.run('extensions', rule, {
     tValid({ code: 'import thing from "./fake-file.js"', options: ['always'] }),
     tValid({ code: 'import thing from "non-package"', options: ['never'] }),
 
+    // Node.js subpath imports (#437)
+    tValid({
+      code: 'import { helper } from "#utils/helper.js"',
+      options: ['always'],
+    }),
+    tValid({
+      code: 'import { helper } from "#utils/helper"',
+      options: ['never'],
+    }),
+    // single-segment subpath imports (e.g. `#dep`) are skipped by the
+    // existing external-root-module classification; deferred (see #437)
+    tValid({ code: 'import dep from "#dep"', options: ['always'] }),
+
     tValid({
       code: `
         import foo from './foo.js'
@@ -655,6 +668,20 @@ ruleTester.run('extensions', rule, {
           data: { importPath: '@name/pkg/test' },
           line: 1,
           column: 19,
+        },
+      ],
+    }),
+
+    // Node.js subpath imports (#437)
+    tInvalid({
+      code: 'import { helper } from "#utils/helper"',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missing',
+          data: { importPath: '#utils/helper' },
+          line: 1,
+          column: 24,
         },
       ],
     }),

--- a/test/utils/__snapshots__/parse-path.spec.ts.snap
+++ b/test/utils/__snapshots__/parse-path.spec.ts.snap
@@ -1,4 +1,36 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`parse-path should parse and stringify path expectedly: #utils/helper 1`] = `
+{
+  "hash": "",
+  "pathname": "#utils/helper",
+  "query": "",
+}
+`;
+
+exports[`parse-path should parse and stringify path expectedly: #utils/helper.js 1`] = `
+{
+  "hash": "",
+  "pathname": "#utils/helper.js",
+  "query": "",
+}
+`;
+
+exports[`parse-path should parse and stringify path expectedly: #utils/helper.js?query 1`] = `
+{
+  "hash": "",
+  "pathname": "#utils/helper.js",
+  "query": "?query",
+}
+`;
+
+exports[`parse-path should parse and stringify path expectedly: #utils/helper?query 1`] = `
+{
+  "hash": "",
+  "pathname": "#utils/helper",
+  "query": "?query",
+}
+`;
 
 exports[`parse-path should parse and stringify path expectedly: foo 1`] = `
 {

--- a/test/utils/parse-path.spec.ts
+++ b/test/utils/parse-path.spec.ts
@@ -8,6 +8,10 @@ describe('parse-path', () => {
       'foo#hash',
       'foo?query#hash',
       'foo#hash?query',
+      '#utils/helper',
+      '#utils/helper.js',
+      '#utils/helper?query',
+      '#utils/helper.js?query',
     ]
 
     for (const input of cases) {


### PR DESCRIPTION
fixes #437 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `extensions` rule to correctly validate Node.js subpath imports like `#utils/helper` instead of misreading them as URL hash fragments (which previously caused extension checking to be skipped).
  * Improved handling and documentation around `#...` imports, ensuring extension validation works as expected for multi-segment specifiers while preserving existing behavior for single-segment `#dep` imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->