### PR TITLE
chore: drop unused `tmp`

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "redux": "^5.0.1",
     "simple-git-hooks": "^2.13.0",
     "tinyexec": "^1.0.1",
-    "tmp": "^0.2.3",
     "ts-node": "^10.9.2",
     "tsdown": "^0.12.9",
     "typescript": "^5.8.3",

--- a/test/rules/no-unused-modules.spec.ts
+++ b/test/rules/no-unused-modules.spec.ts
@@ -1,6 +1,8 @@
 import { execSync } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
 import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 import { jest } from '@jest/globals'
 import { RuleTester as TSESLintRuleTester } from '@typescript-eslint/rule-tester'
@@ -9,7 +11,6 @@ import type { TSESLint } from '@typescript-eslint/utils'
 // eslint-disable-next-line import-x/default -- incorrect types
 import eslint8UnsupportedApi from 'eslint8.56/use-at-your-own-risk'
 import { RuleTester as ESLint9_FlatRuleTester } from 'eslint9'
-import { dirSync } from 'tmp'
 
 import {
   createRuleTestCaseFunctions,
@@ -1597,9 +1598,7 @@ function createUnusedError(
   ;(isESLint9 ? describe : describe.skip)('with eslint 9 only', () => {
     it('provides meaningful error when eslintrc is not present', () => {
       // Create temp directory outside of project root
-      const { name: tempDir, removeCallback } = dirSync({
-        unsafeCleanup: true,
-      })
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'import-x-test-'))
 
       // Copy example project to temp directory
       // eslint-disable-next-line n/no-unsupported-features/node-builtins -- false positive
@@ -1627,7 +1626,7 @@ function createUnusedError(
       )
 
       // Cleanup
-      removeCallback()
+      fs.rmSync(tempDir, { recursive: true, force: true })
     }, 100_000)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6135,7 +6135,6 @@ __metadata:
     simple-git-hooks: "npm:^2.13.0"
     stable-hash-x: "npm:^0.2.0"
     tinyexec: "npm:^1.0.1"
-    tmp: "npm:^0.2.3"
     ts-node: "npm:^10.9.2"
     tsdown: "npm:^0.12.9"
     typescript: "npm:^5.8.3"
@@ -12578,13 +12577,6 @@ __metadata:
   dependencies:
     os-tmpdir: "npm:~1.0.2"
   checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.3":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #485

We don't need a `tmp` package just for unit testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused development dependency.
* **Tests**
  * Updated a test to stop using an external temp library and instead use native OS/temp directory creation and cleanup for the ESLint-related scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->