### PR TITLE
fix: ignore TS namespace members for no-named-as-default{,-member}

### DIFF
--- a/.changeset/shy-wasps-act.md
+++ b/.changeset/shy-wasps-act.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+Ignore TypeScript `namespace` members for `no-named-as-default`, `no-named-as-default-member` rules

--- a/src/rules/no-named-as-default-member.ts
+++ b/src/rules/no-named-as-default-member.ts
@@ -101,6 +101,15 @@ export default createRule<[], MessageId>({
             if (propName === 'default') {
               continue
             }
+
+            if (fileImport.exportMap.hasExportAssignment) {
+              // A member of an `export = ns` assignment cannot be consumed via
+              // named import at runtime (unless the consumer is transpiled to
+              // CommonJS), so consuming it via the default import is not a
+              // mistake.
+              continue
+            }
+
             if (!fileImport.exportMap.namespace.has(propName)) {
               continue
             }

--- a/src/rules/no-named-as-default.ts
+++ b/src/rules/no-named-as-default.ts
@@ -61,6 +61,13 @@ export default createRule<[], MessageId>({
           return
         }
 
+        if (exportMapOfImported.hasExportAssignment) {
+          // A member of an `export = ns` assignment cannot be consumed via
+          // named import at runtime (unless the consumer is transpiled to
+          // CommonJS), so importing the default by that name is not a mistake.
+          return
+        }
+
         if (
           exportMapOfImported.exports.has('default') &&
           exportMapOfImported.exports.has(nameValue)

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -518,6 +518,8 @@ export class ExportMap {
 
       // This doesn't declare anything, but changes what's being exported.
       if (n.type === 'TSExportAssignment') {
+        m.hasExportAssignment = true
+
         const exportedName =
           ('expression' in n &&
             n.expression &&
@@ -698,6 +700,9 @@ export class ExportMap {
   /** Dependencies of this module that are not explicitly re-exported */
   imports = new Map<string, ModuleImport>()
   exports = new Map<string, TSESTree.Identifier | TSESTree.ProgramStatement>()
+
+  /** Whether this module has an `export = ns` assignment */
+  hasExportAssignment = false
 
   errors: ParseError[] = []
 

--- a/src/utils/export-map.ts
+++ b/src/utils/export-map.ts
@@ -516,27 +516,16 @@ export class ExportMap {
         }
       }
 
-      const exports = ['TSExportAssignment']
-      if (isEsModuleInteropTrue()) {
-        exports.push('TSNamespaceExportDeclaration')
-      }
-
       // This doesn't declare anything, but changes what's being exported.
-      if (exports.includes(n.type)) {
+      if (n.type === 'TSExportAssignment') {
         const exportedName =
-          n.type === 'TSNamespaceExportDeclaration'
-            ? (
-                n.id ||
-                // @ts-expect-error - legacy parser type
-                n.name
-              ).name
-            : ('expression' in n &&
-                n.expression &&
-                (('name' in n.expression && n.expression.name) ||
-                  ('id' in n.expression &&
-                    n.expression.id &&
-                    n.expression.id.name))) ||
-              null
+          ('expression' in n &&
+            n.expression &&
+            (('name' in n.expression && n.expression.name) ||
+              ('id' in n.expression &&
+                n.expression.id &&
+                n.expression.id.name))) ||
+          null
 
         const getRoot = (
           node: TSESTree.TSQualifiedName,

--- a/test/rules/no-named-as-default-member.spec.ts
+++ b/test/rules/no-named-as-default-member.spec.ts
@@ -6,6 +6,7 @@ import {
   createRuleTestCaseFunctions,
   SYNTAX_VALID_CASES,
   parsers,
+  testFilePath,
 } from '../utils.js'
 import type { GetRuleModuleMessageIds, RuleRunTests } from '../utils.js'
 
@@ -40,6 +41,14 @@ ruleTester.run('no-named-as-default-member', rule, {
         parser: require(parsers.ESPREE),
         parserOptions: { ecmaVersion: 2022 },
       },
+    }),
+    tValid({
+      code: `import ns from "./typescript-export-assign-namespace"; ns.getFoo();`,
+      settings: {
+        'import-x/parsers': { [parsers.TS]: ['.ts'] },
+        'import-x/resolver': { 'eslint-import-resolver-typescript': true },
+      },
+      languageOptions: { parserOptions: { tsconfigRootDir: testFilePath('') } },
     }),
 
     ...(SYNTAX_VALID_CASES as RuleRunTests<typeof rule>['valid']),

--- a/test/rules/no-named-as-default.spec.ts
+++ b/test/rules/no-named-as-default.spec.ts
@@ -6,6 +6,7 @@ import {
   createRuleTestCaseFunctions,
   SYNTAX_VALID_CASES,
   parsers,
+  testFilePath,
 } from '../utils.js'
 import type { GetRuleModuleMessageIds, RuleRunTests } from '../utils.js'
 
@@ -98,6 +99,15 @@ ruleTester.run('no-named-as-default', rule, {
         parser: require(parsers.ESPREE),
         parserOptions: { ecmaVersion: 2022 },
       },
+    }),
+
+    tValid({
+      code: `import getFoo from "./typescript-export-assign-namespace"`,
+      settings: {
+        'import-x/parsers': { [parsers.TS]: ['.ts'] },
+        'import-x/resolver': { 'eslint-import-resolver-typescript': true },
+      },
+      languageOptions: { parserOptions: { tsconfigRootDir: testFilePath('') } },
     }),
 
     ...(SYNTAX_VALID_CASES as RuleRunTests<typeof rule>['valid']),


### PR DESCRIPTION
An `export as namespace ns` declaration, `TSNamespaceExportDeclaration`, doesn’t make any contribution to what can be accessed from a module via `import` (whether or not `esModuleInterop` is enabled). Instead, it declares the namespace that can be accessed via a UMD global variable.

A member of an `export = ns` assignment cannot be consumed via named import at runtime (unless the consumer is transpiled to CommonJS), so it is not a mistake to consume it via the default import, or to import the default by that name.

For example, `import assert from "minimalistic-assert"; assert.equal(…)` should not trigger `no-named-as-default-member`, and `import webpack from "webpack"` should not trigger `no-named-as-default`.

- Fixes #491.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rules no longer flag valid TypeScript namespace-style exports (export = ns) as erroneous for default/named import checks.

* **Tests**
  * Added test cases covering TypeScript namespace-style exports with TypeScript-aware resolver/parser settings.

* **Chores**
  * Release patch recorded documenting the rule behavior adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->