### PR TITLE
Handle access-denied directories during case checks

### DIFF
--- a/.changeset/case-check-access-errors.md
+++ b/.changeset/case-check-access-errors.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+Fixed `no-unresolved` crashing when case-sensitive path checks encounter `EACCES` or `EPERM` on an ancestor directory.

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -45,6 +45,15 @@ export const IMPORT_RESOLVE_ERROR_NAME = 'EslintPluginImportResolveError'
 
 export const fileExistsCache = new ModuleCache()
 
+function isDirectoryAccessError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error != null &&
+    'code' in error &&
+    (error.code === 'EACCES' || error.code === 'EPERM')
+  )
+}
+
 // https://stackoverflow.com/a/27382838
 export function fileExistsWithCaseSync(
   filepath: string | null,
@@ -76,14 +85,24 @@ export function fileExistsWithCaseSync(
   if (dir === '' || parsedPath.root === filepath) {
     result = true
   } else {
-    const filenames = fs.readdirSync(dir)
-    result = filenames.includes(parsedPath.base)
-      ? fileExistsWithCaseSync(dir, cacheSettings, strict, false)
-      : !leaf &&
-        // We tolerate case-insensitive matches if there are no case-insensitive matches.
-        // It'll fail anyway on the leaf node if the file truly doesn't exist (if it doesn't
-        // fail it's that we're probably working with a virtual in-memory filesystem).
-        !filenames.some(p => p.toLowerCase() === parsedPath.base.toLowerCase())
+    try {
+      const filenames = fs.readdirSync(dir)
+      result = filenames.includes(parsedPath.base)
+        ? fileExistsWithCaseSync(dir, cacheSettings, strict, false)
+        : !leaf &&
+          // We tolerate case-insensitive matches if there are no case-insensitive matches.
+          // It'll fail anyway on the leaf node if the file truly doesn't exist (if it doesn't
+          // fail it's that we're probably working with a virtual in-memory filesystem).
+          !filenames.some(
+            p => p.toLowerCase() === parsedPath.base.toLowerCase(),
+          )
+    } catch (error) {
+      if (isDirectoryAccessError(error)) {
+        result = true
+      } else {
+        throw error
+      }
+    }
   }
   fileExistsCache.set(filepath, result)
   return result

--- a/test/utils/resolve.spec.ts
+++ b/test/utils/resolve.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
+import os from 'node:os'
 import path from 'node:path'
 import { setTimeout } from 'node:timers/promises'
 
@@ -490,6 +491,40 @@ describe('resolve', () => {
       )
       expect(fileExistsWithCaseSync(f, cacheSettings, true)).toBe(false)
     })
+
+    for (const code of ['EACCES', 'EPERM'] as const) {
+      it(`does not throw when ancestor directory access is denied outside cwd (${code})`, () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'import-x-case-'))
+        const blockedDir = path.join(root, 'source')
+        const sharedDir = path.join(blockedDir, 'shared')
+        const file = path.join(sharedDir, 'account.db.ts')
+
+        fs.mkdirSync(sharedDir, { recursive: true })
+        fs.writeFileSync(file, 'export {}\n')
+
+        const originalReaddirSync = fs.readdirSync
+        const readdirSpy = jest.spyOn(fs, 'readdirSync').mockImplementation(((
+          dir: Parameters<typeof fs.readdirSync>[0],
+        ) => {
+          if (path.resolve(String(dir)) === blockedDir) {
+            const error = new Error(`${code}: permission denied`) as Error & {
+              code: string
+            }
+            error.code = code
+            throw error
+          }
+
+          return originalReaddirSync(dir)
+        }) as typeof fs.readdirSync)
+
+        try {
+          expect(fileExistsWithCaseSync(file, cacheSettings)).toBe(true)
+        } finally {
+          readdirSpy.mockRestore()
+          fs.rmSync(root, { recursive: true, force: true })
+        }
+      })
+    }
   })
 
   describe('rename cache correctness', () => {


### PR DESCRIPTION
`no-unresolved` could resolve an import successfully, then crash during its case-sensitive path check if reading an ancestor directory returned `EACCES` or `EPERM`.
This treats those access errors as casing being unverifiable while keeping the resolved path valid. Other filesystem errors still throw.
I checked both error cases on Node 22 and Node 26, the full resolve test file passing 40/40, typecheck, build, ESLint, patch-package checks, and `git diff --check`.
Fixes #483