### PR TITLE
docs: document the `esmodule` option for `no-dynamic-require` rule

### DIFF
--- a/.changeset/quiet-forks-cheer.md
+++ b/.changeset/quiet-forks-cheer.md
@@ -1,5 +1,0 @@
----
-"eslint-plugin-import-x": patch
----
-
-no-dynamic-require: document the `esmodule` option

--- a/.changeset/quiet-forks-cheer.md
+++ b/.changeset/quiet-forks-cheer.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+no-dynamic-require: document the `esmodule` option

--- a/docs/rules/no-dynamic-require.md
+++ b/docs/rules/no-dynamic-require.md
@@ -6,6 +6,38 @@ The `require` method from CommonJS is used to import modules from different file
 
 This rule forbids every call to `require()` that uses expressions for the module name argument.
 
+## Options
+
+This rule supports the following options:
+
+### `esmodule`
+
+By default, this rule does not report dynamic `import()` expressions.
+
+Given `{ "esmodule": true }`:
+
+<!-- lint disable no-duplicate-headings-in-section -->
+
+### Fail
+
+```js
+import(name)
+import('../' + name)
+import(`../${name}`)
+import(name())
+```
+
+<!-- lint disable no-duplicate-headings-in-section -->
+
+### Pass
+
+```js
+import('foo')
+import(`foo`)
+import('./foo')
+import('@scope/foo')
+```
+
 ## Rule Details
 
 ### Fail


### PR DESCRIPTION
this PR documents the `esmodule` option for `no-dynamic-require` rule. Fixes #467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the `esmodule` option in the `no-dynamic-require` rule, including detailed examples of allowed and disallowed dynamic import patterns.

* **Chores**
  * Version bump for `eslint-plugin-import-x` (patch release).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->