### PR TITLE
fix(extensions): don't require extension for package subpaths resolving to .d.ts

### DIFF
--- a/.changeset/extensions-dts-package-subpath.md
+++ b/.changeset/extensions-dts-package-subpath.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+fix(extensions): don't require an extension for package subpaths that resolve to a `.d.ts` (e.g. `vitest/config`)

--- a/src/rules/extensions.ts
+++ b/src/rules/extensions.ts
@@ -329,15 +329,12 @@ export default createRule<Options, MessageId>({
         }
 
         const resolvedPath = resolve(importPath, context)
+        const resolvedToDts = !!resolvedPath && dtsRe.test(resolvedPath)
 
         // get extension from resolved path, or source value if unresolved.
         // for .d.ts/.d.mts/.d.cts, use the import path extension instead.
         const extension = path
-          .extname(
-            resolvedPath && dtsRe.test(resolvedPath)
-              ? importPath
-              : resolvedPath || importPath,
-          )
+          .extname(resolvedToDts ? importPath : resolvedPath || importPath)
           .slice(1)
 
         // determine if this is a module
@@ -349,6 +346,13 @@ export default createRule<Options, MessageId>({
           ) || isScoped(importPath)
 
         if (!extension || !importPath.endsWith(`.${extension}`)) {
+          // A package subpath that resolves to a type declaration
+          // (.d.ts/.d.mts/.d.cts) has no runtime extension to enforce — the
+          // entry point is governed by the package's "exports" map
+          // (e.g. `vitest/config`, `eslint/config`).
+          if (resolvedToDts && !extension && isPackage) {
+            return
+          }
           // ignore type-only imports and exports
           if (
             !props.checkTypeImports &&

--- a/test/fixtures/node_modules/dts-subpath-package/config.d.ts
+++ b/test/fixtures/node_modules/dts-subpath-package/config.d.ts
@@ -1,0 +1,1 @@
+export declare function defineConfig(config: unknown): unknown

--- a/test/fixtures/node_modules/dts-subpath-package/config.js
+++ b/test/fixtures/node_modules/dts-subpath-package/config.js
@@ -1,0 +1,3 @@
+export function defineConfig(config) {
+  return config
+}

--- a/test/fixtures/node_modules/dts-subpath-package/index.d.ts
+++ b/test/fixtures/node_modules/dts-subpath-package/index.d.ts
@@ -1,0 +1,1 @@
+export declare const foo: string

--- a/test/fixtures/node_modules/dts-subpath-package/index.js
+++ b/test/fixtures/node_modules/dts-subpath-package/index.js
@@ -1,0 +1,1 @@
+export const foo = 'bar'

--- a/test/fixtures/node_modules/dts-subpath-package/package.json
+++ b/test/fixtures/node_modules/dts-subpath-package/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dts-subpath-package",
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./config": {
+      "types": "./config.d.ts",
+      "default": "./config.js"
+    }
+  }
+}

--- a/test/rules/extensions.spec.ts
+++ b/test/rules/extensions.spec.ts
@@ -1282,6 +1282,24 @@ describe('TypeScript', () => {
         options: ['always'],
       }),
 
+      // an extensionless package subpath that resolves to a `.d.ts` declaration
+      // (via the TypeScript resolver's types-first conditions) has no runtime
+      // extension to enforce (e.g. `vitest/config`) — #468 regression
+      tValid({
+        code: 'import { defineConfig } from "dts-subpath-package/config";',
+        options: ['always'],
+        settings: {
+          'import-x/resolver': { typescript: { alwaysTryTypes: true } },
+        },
+      }),
+      tValid({
+        code: 'import { defineConfig } from "dts-subpath-package/config";',
+        options: ['always', { ts: 'never' }],
+        settings: {
+          'import-x/resolver': { typescript: { alwaysTryTypes: true } },
+        },
+      }),
+
       // pathGroupOverrides: no patterns match good bespoke specifiers
       tValid({
         code: `


### PR DESCRIPTION
- fixes #497 

Fixes a false `import-x/extensions` "Missing file extension" report for extensionless package subpath imports that resolve to a `.d.ts` (e.g. `vitest/config`).

## Why

#468 reads the extension from the import path when resolution lands on a `.d.ts`. 
For an extensionless package subpath `path.extname('vitest/config')` is `''`, so the rule demands an extension that can never exist, the entry point is governed by `"exports"`.

## Fix

In `src/rules/extensions.ts`, bail out of the missing-extension branch when resolution is `.d.ts`, the import path has no extension, and it is a package.
The #468 relative case (`./dist-import/index.js`) is unaffected — it has a `.js` extension, so the guard never triggers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of package subpaths that resolve to type declaration files, so extensionless imports like `vitest/config` are no longer incorrectly flagged.
  * Made extension checks smarter when a resolved import points to a `.d.ts`-style file.
* **Tests**
  * Added coverage for extensionless TypeScript package subpaths and related configuration behavior.
* **Chores**
  * Added a release note entry for the patch update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->