### PR TITLE
feat(order): support `warnOnUnassignedImports: "top"`

### DIFF
--- a/.changeset/order-top-unassigned.md
+++ b/.changeset/order-top-unassigned.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": minor
+---
+
+Add a `"top"` mode to the `order` rule's `warnOnUnassignedImports` option for requiring no-specifier ESM imports before assigned imports.

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -515,11 +515,14 @@ import { apply, compose } from 'xcompose'
 
 ### `warnOnUnassignedImports`
 
-Valid values: `boolean` \
+Valid values: `boolean | "top"` \
 Default: `false`
 
-Warn when "unassigned" imports are out of order.
+When set to `true`, warn when "unassigned" imports are out of order.
 Unassigned imports are imports with no corresponding identifiers (e.g. `import './my/thing.js'` or `require('./side-effects.js')`).
+
+When set to `"top"`, no-specifier ESM imports (e.g. `import './my/thing.js'`) must come before every assigned import.
+Their relative order is preserved, they are not alphabetized, and bare `require()` calls are unaffected.
 
 > [!NOTE]
 >
@@ -555,6 +558,35 @@ While this will pass:
 import fs from 'fs'
 import path from 'path'
 import './styles.css'
+```
+
+#### `"top"` mode
+
+Given the following settings:
+
+```jsonc
+{
+  "import-x/order": [
+    "error",
+    {
+      "warnOnUnassignedImports": "top",
+    },
+  ],
+}
+```
+
+This will fail the rule check:
+
+```ts
+import fs from 'fs'
+import './styles.css'
+```
+
+While this will pass:
+
+```ts
+import './styles.css'
+import fs from 'fs'
 ```
 
 ### `sortTypesGroup`

--- a/src/rules/order.ts
+++ b/src/rules/order.ts
@@ -52,6 +52,7 @@ const defaultGroups = [
   'sibling',
   'index',
 ] as const
+const unassignedImportsTopRank = Number.NEGATIVE_INFINITY
 
 // REPORTING AND FIXING
 
@@ -286,6 +287,12 @@ function isPlainImportModule(
     node.type === 'ImportDeclaration' &&
     node.specifiers != null &&
     node.specifiers.length > 0
+  )
+}
+
+function isUnassignedImport(node: ImportEntry) {
+  return (
+    node.node.type === 'ImportDeclaration' && node.node.specifiers.length === 0
   )
 }
 
@@ -776,14 +783,17 @@ function registerNode(
   imported: ImportEntryWithRank[],
   excludedImportTypes: Set<ImportType>,
   isSortingTypesGroup?: boolean,
+  rankOverride?: number,
 ) {
-  const rank = computeRank(
-    context,
-    ranks,
-    importEntry,
-    excludedImportTypes,
-    isSortingTypesGroup,
-  )
+  const rank =
+    rankOverride ??
+    computeRank(
+      context,
+      ranks,
+      importEntry,
+      excludedImportTypes,
+      isSortingTypesGroup,
+    )
   if (rank !== -1) {
     let importNode = importEntry.node
 
@@ -956,6 +966,7 @@ function makeNewlinesBetweenReport(
   distinctGroup: boolean,
   isSortingTypesGroup?: boolean,
   isConsolidatingSpaceBetweenImports?: boolean,
+  disableUnassignedImportFixes?: boolean,
 ) {
   const getNumberOfEmptyLinesBetween = (
     currentImport: ImportEntry,
@@ -975,6 +986,9 @@ function makeNewlinesBetweenReport(
   let previousImport = imported[0]
 
   for (const currentImport of imported.slice(1)) {
+    const shouldDisableFix =
+      disableUnassignedImportFixes &&
+      (isUnassignedImport(previousImport) || isUnassignedImport(currentImport))
     const emptyLinesBetween = getNumberOfEmptyLinesBetween(
       currentImport,
       previousImport,
@@ -1062,7 +1076,9 @@ function makeNewlinesBetweenReport(
             context.report({
               node: previousImport.node,
               messageId: 'oneLineBetweenGroups',
-              fix: fixNewLineAfterImport(context, previousImport),
+              fix: shouldDisableFix
+                ? null
+                : fixNewLineAfterImport(context, previousImport),
             })
           }
         } else if (
@@ -1074,11 +1090,13 @@ function makeNewlinesBetweenReport(
           context.report({
             node: previousImport.node,
             messageId: 'noLineWithinGroup',
-            fix: removeNewLineAfterImport(
-              context,
-              currentImport,
-              previousImport,
-            ),
+            fix: shouldDisableFix
+              ? null
+              : removeNewLineAfterImport(
+                  context,
+                  currentImport,
+                  previousImport,
+                ),
           })
         }
       } else if (emptyLinesBetween > 0 && shouldAssertNoNewlineBetweenGroup) {
@@ -1086,7 +1104,9 @@ function makeNewlinesBetweenReport(
         context.report({
           node: previousImport.node,
           messageId: 'noLineBetweenGroups',
-          fix: removeNewLineAfterImport(context, currentImport, previousImport),
+          fix: shouldDisableFix
+            ? null
+            : removeNewLineAfterImport(context, currentImport, previousImport),
         })
       }
 
@@ -1095,13 +1115,17 @@ function makeNewlinesBetweenReport(
           context.report({
             node: previousImport.node,
             messageId: 'oneLineBetweenTheMultiLineImport',
-            fix: fixNewLineAfterImport(context, previousImport),
+            fix: shouldDisableFix
+              ? null
+              : fixNewLineAfterImport(context, previousImport),
           })
         } else if (emptyLinesBetween === 0 && previousImport.isMultiline) {
           context.report({
             node: previousImport.node,
             messageId: 'oneLineBetweenThisMultiLineImport',
-            fix: fixNewLineAfterImport(context, previousImport),
+            fix: shouldDisableFix
+              ? null
+              : fixNewLineAfterImport(context, previousImport),
           })
         } else if (
           emptyLinesBetween > 0 &&
@@ -1112,11 +1136,13 @@ function makeNewlinesBetweenReport(
           context.report({
             node: previousImport.node,
             messageId: 'noLineBetweenSingleLineImport',
-            fix: removeNewLineAfterImport(
-              context,
-              currentImport,
-              previousImport,
-            ),
+            fix: shouldDisableFix
+              ? null
+              : removeNewLineAfterImport(
+                  context,
+                  currentImport,
+                  previousImport,
+                ),
           })
         }
       }
@@ -1148,7 +1174,7 @@ export interface Options {
   pathGroupsExcludedImportTypes?: ImportType[]
   pathGroups?: PathGroup[]
   sortTypesGroup?: boolean
-  warnOnUnassignedImports?: boolean
+  warnOnUnassignedImports?: boolean | 'top'
 }
 
 type MessageId =
@@ -1268,7 +1294,7 @@ export default createRule<[Options?], MessageId>({
             additionalProperties: false,
           },
           warnOnUnassignedImports: {
-            type: 'boolean',
+            oneOf: [{ type: 'boolean' }, { type: 'string', enum: ['top'] }],
             default: false,
           },
         },
@@ -1475,6 +1501,10 @@ export default createRule<[Options?], MessageId>({
             getBlockImports(node.parent),
             pathGroupsExcludedImportTypes,
             isSortingTypesGroup,
+            node.specifiers.length === 0 &&
+              options.warnOnUnassignedImports === 'top'
+              ? unassignedImportsTopRank
+              : undefined,
           )
 
           if (named.import) {
@@ -1672,11 +1702,17 @@ export default createRule<[Options?], MessageId>({
                 (newlinesBetweenImports === 'always-and-inside-groups' ||
                   newlinesBetweenTypeOnlyImports ===
                     'always-and-inside-groups'),
+              options.warnOnUnassignedImports === 'top',
             )
           }
 
           if (alphabetize.order !== 'ignore') {
-            mutateRanksToAlphabetize(imported, alphabetize)
+            mutateRanksToAlphabetize(
+              options.warnOnUnassignedImports === 'top'
+                ? imported.filter(node => !isUnassignedImport(node))
+                : imported,
+              alphabetize,
+            )
           }
 
           makeOutOfOrderReport(context, imported, categories.import)

--- a/src/rules/order.ts
+++ b/src/rules/order.ts
@@ -982,7 +982,9 @@ function makeNewlinesBetweenReport(
   const getIsStartOfDistinctGroup = (
     currentImport: ImportEntryWithRank,
     previousImport: ImportEntryWithRank,
-  ) => currentImport.rank - 1 >= previousImport.rank
+  ) =>
+    currentImport.rank !== previousImport.rank &&
+    currentImport.rank - 1 >= previousImport.rank
   let previousImport = imported[0]
 
   for (const currentImport of imported.slice(1)) {

--- a/test/rules/order.spec.ts
+++ b/test/rules/order.spec.ts
@@ -169,6 +169,41 @@ ruleTester.run('order', rule, {
         import path from 'path';
     `,
     }),
+    // Place unassigned ESM imports before assigned imports in top mode
+    tValid({
+      code: `
+        import './z-side';
+        import './a-side';
+        import fs from 'node:fs';
+        import external from 'external';
+      `,
+      options: [{ warnOnUnassignedImports: 'top' }],
+    }),
+    // Do not alphabetize unassigned ESM imports in top mode
+    tValid({
+      code: `
+        import './z-side';
+        import './a-side';
+        import a from 'a';
+        import z from 'z';
+      `,
+      options: [
+        {
+          alphabetize: { order: 'asc' },
+          warnOnUnassignedImports: 'top',
+        },
+      ],
+    }),
+    // Keep bare require calls outside top mode
+    tValid({
+      code: `
+        const fs = require('node:fs');
+        require('./z-side');
+        const path = require('node:path');
+        require('./a-side');
+      `,
+      options: [{ warnOnUnassignedImports: 'top' }],
+    }),
     // No imports
     tValid({
       code: `
@@ -3144,6 +3179,56 @@ ruleTester.run('order', rule, {
         createOrderError(['`b` export', 'before', 'export of `o`']),
       ],
     }),
+    // Report without fixing when an unassigned ESM import is below an assigned import
+    tInvalid({
+      code: `
+        import fs from 'node:fs';
+        import './side.js';
+        import path from 'node:path';
+      `,
+      options: [{ warnOnUnassignedImports: 'top' }],
+      errors: [
+        createOrderError([
+          '`./side.js` import',
+          'before',
+          'import of `node:fs`',
+        ]),
+      ],
+      output: null,
+    }),
+    // Preserve comments and relative order when multiple unassigned imports are below an assigned import
+    tInvalid({
+      code: `
+        import external from 'external';
+        // first side effect
+        import './z-side';
+        import './a-side'; // second side effect
+      `,
+      options: [{ warnOnUnassignedImports: 'top' }],
+      errors: [
+        createOrderError([
+          '`external` import',
+          'after',
+          'import of `./a-side`',
+        ]),
+      ],
+      output: null,
+    }),
+    // Report but do not fix newline separation involving top-mode unassigned imports
+    tInvalid({
+      code: `
+        import './side.js';
+        import fs from 'node:fs';
+      `,
+      options: [
+        {
+          'newlines-between': 'always',
+          warnOnUnassignedImports: 'top',
+        },
+      ],
+      errors: [{ messageId: 'oneLineBetweenGroups', line: 2 }],
+      output: null,
+    }),
   ],
 })
 
@@ -3832,6 +3917,22 @@ describe('TypeScript', () => {
               groups: ['builtin', 'type', 'unknown', 'external'],
               sortTypesGroup: true,
               'newlines-between': 'always',
+            },
+          ],
+        }),
+        // Keep top-mode unassigned imports before custom groups and type-only imports
+        tValid({
+          code: `
+            import './side.js';
+            import type { Config } from 'types';
+            import fs from 'node:fs';
+            import external from 'external';
+          `,
+          ...parserConfig,
+          options: [
+            {
+              groups: ['type', 'builtin', 'external'],
+              warnOnUnassignedImports: 'top',
             },
           ],
         }),

--- a/test/rules/order.spec.ts
+++ b/test/rules/order.spec.ts
@@ -3229,6 +3229,23 @@ ruleTester.run('order', rule, {
       errors: [{ messageId: 'oneLineBetweenGroups', line: 2 }],
       output: null,
     }),
+    // Treat adjacent top-mode unassigned imports as one group for newline validation
+    tInvalid({
+      code: `
+        import './a-side.js';
+
+        import './b-side.js';
+      `,
+      options: [
+        {
+          'newlines-between': 'always',
+          distinctGroup: false,
+          warnOnUnassignedImports: 'top',
+        },
+      ],
+      errors: [{ messageId: 'noLineWithinGroup', line: 2 }],
+      output: null,
+    }),
   ],
 })
 


### PR DESCRIPTION
`warnOnUnassignedImports` takes a third value, `"top"`, requiring no-specifier ESM imports (`import './side.js'`) to come before every assigned import. The mode reports without fixing, keeps the relative order of those imports, leaves them out of `alphabetize`, and changes nothing about `true`, `false`, or bare `require()` calls.

I checked released 4.17.1 behavior with a fixture matrix before building this, and every existing boolean and default cell comes back byte-identical against the built rule.

The value name follows JounQin's suggestion in the thread and fregante's confirmation. Bare-`require()` parity stays out of this pass — happy to follow up with it if you'd like.

Closes #500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `"top"` mode for the `order` rule’s `warnOnUnassignedImports` option.
  * Unassigned ESM imports can be required to appear before assigned imports, custom groups, and type-only imports while preserving their relative order.
  * Unassigned imports are excluded from alphabetization in this mode.

* **Bug Fixes**
  * Bare `require()` calls remain unaffected.
  * Automatic fixes preserve unassigned import order, grouping, comments, and spacing.

* **Documentation**
  * Added configuration details and examples for the new option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->