### PR TITLE
perf(no-cycle): avoid duplicate dependency traversal

### DIFF
--- a/.changeset/no-cycle-dependency-traversal.md
+++ b/.changeset/no-cycle-dependency-traversal.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-import-x": patch
+---
+
+Reduce `no-cycle` CPU usage for converging dependency graphs.

--- a/src/rules/no-cycle.ts
+++ b/src/rules/no-cycle.ts
@@ -23,6 +23,10 @@ export interface Traverser {
   route: Array<DeclarationMetadata['source']>
 }
 
+interface QueuedTraverser extends Traverser {
+  path: string
+}
+
 const traversed = new Set<string>()
 
 export default createRule<[Options?], MessageId>({
@@ -126,7 +130,15 @@ export default createRule<[Options?], MessageId>({
           return // no-self-import territory
         }
 
-        const untraversed: Traverser[] = [{ mget: () => imported, route: [] }]
+        if (traversed.has(imported.path)) {
+          return
+        }
+
+        traversed.add(imported.path)
+
+        const untraversed: QueuedTraverser[] = [
+          { mget: () => imported, path: imported.path, route: [] },
+        ]
 
         function detectCycle({ mget, route }: Traverser) {
           const m = mget()
@@ -134,12 +146,6 @@ export default createRule<[Options?], MessageId>({
           if (m == null) {
             return
           }
-
-          if (traversed.has(m.path)) {
-            return
-          }
-
-          traversed.add(m.path)
 
           for (const [path, { getter, declarations }] of m.imports) {
             if (traversed.has(path)) {
@@ -176,10 +182,13 @@ export default createRule<[Options?], MessageId>({
             if (path === filename && toTraverse.length > 0) {
               return true
             }
-            if (route.length + 1 < maxDepth) {
-              for (const { source } of toTraverse) {
-                untraversed.push({ mget: getter, route: [...route, source] })
-              }
+            if (route.length + 1 < maxDepth && toTraverse.length > 0) {
+              traversed.add(path)
+              untraversed.push({
+                mget: getter,
+                path,
+                route: [...route, toTraverse[0].source],
+              })
             }
           }
         }
@@ -187,6 +196,10 @@ export default createRule<[Options?], MessageId>({
         while (untraversed.length > 0) {
           const next = untraversed.shift()! // bfs!
           if (detectCycle(next)) {
+            // Pending modules may still be imported elsewhere in this file.
+            for (const { path } of untraversed) {
+              traversed.delete(path)
+            }
             if (next.route.length > 0) {
               context.report({
                 node: importer,

--- a/test/fixtures/cycles/siblings/first-cycle.js
+++ b/test/fixtures/cycles/siblings/first-cycle.js
@@ -1,0 +1,3 @@
+import root from '../depth-zero'
+
+export default root

--- a/test/fixtures/cycles/siblings/first.js
+++ b/test/fixtures/cycles/siblings/first.js
@@ -1,0 +1,4 @@
+import firstCycle from './first-cycle'
+import second from './second'
+
+export default [firstCycle, second]

--- a/test/fixtures/cycles/siblings/second.js
+++ b/test/fixtures/cycles/siblings/second.js
@@ -1,0 +1,3 @@
+import root from '../depth-zero'
+
+export default root

--- a/test/rules/no-cycle.spec.ts
+++ b/test/rules/no-cycle.spec.ts
@@ -269,5 +269,16 @@ ruleTester.run('no-cycle', rule, {
       code: 'import { foo } from "./ignore"',
       errors: [{ messageId: 'cycle', line: 1 }],
     }),
+    tInvalid({
+      code: [
+        'import first from "./siblings/first"',
+        'import second from "./siblings/second"',
+        'import firstAgain from "./siblings/first"',
+      ].join('\n'),
+      errors: [
+        { ...createCycleSourceError('./first-cycle:1'), line: 1 },
+        { messageId: 'cycle', line: 2 },
+      ],
+    }),
   ],
 })


### PR DESCRIPTION
Converging import graphs can queue the same module more than once, which repeats export-map work. The rule now marks paths when queued.Pending paths are released after an early cycle report. This keeps sibling imports independently checked.Seven cold automatic-concurrency runs reduced user CPU from 1.488 to 1.306 seconds. A fresh repeat measured 1.684 to 1.540 seconds. Wall time stayed within noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced CPU usage for the `no-cycle` rule when analyzing dependency graphs with converging paths.
  - Improved traversal efficiency while preserving cycle detection across related modules.

- **Bug Fixes**
  - Improved detection and reporting of cycles involving sibling modules and repeated imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->